### PR TITLE
Using `env` variables for app settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,12 @@
 {
-  "cSpell.words": ["Dios", "pydantic", "uvicorn"]
+  "cSpell.words": [
+    "autoflush",
+    "Dios",
+    "diosvo",
+    "pkey",
+    "pydantic",
+    "sessionmaker",
+    "SQLALCHEMY",
+    "uvicorn"
+  ]
 }

--- a/server/alembic/env.py
+++ b/server/alembic/env.py
@@ -1,20 +1,11 @@
-from logging.config import fileConfig
-
 from alembic import context
 from alembic.runtime.migration import MigrationContext, MigrationInfo
 from sqlalchemy import engine_from_config, pool, text
-from src.database import DATABASE_URL, metadata
+from src.database import DATABASE_DSN, metadata
 
 # Alembic Config object, which provides access to the values within the `.ini` file in use.
 config = context.config
-config.set_main_option(
-    name="sqlalchemy.url", value=f"postgresql+psycopg2://{DATABASE_URL}"
-)
-
-# Interpret the config file for Python logging.
-# This line sets up loggers basically.
-if config.config_file_name is not None:
-    fileConfig(config.config_file_name)
+config.set_main_option(name="sqlalchemy.url", value=DATABASE_DSN)
 
 
 def include_name(name: str, type_: str, **kwargs) -> bool:
@@ -36,7 +27,7 @@ def update_history(ctx: MigrationContext, step: MigrationInfo, **kwargs) -> None
         message = step.up_revision.doc
         # Ensure that single quotes in the message are escaped properly
         message = message.replace("'", "''")
-        
+
         sql_command = text(
             "INSERT INTO alembic_version_history (version_num, message, applied_at) VALUES (:revision_id, :message, NOW())"
         )

--- a/server/src/database.py
+++ b/server/src/database.py
@@ -5,6 +5,10 @@ Database connection related "stuff".
 from sqlalchemy import MetaData, create_engine
 from sqlalchemy.orm import sessionmaker
 
+from .config import get_settings
+
+settings = get_settings()
+
 POSTGRES_INDEXES_NAMING_CONVENTION = {
     "ix": "%(column_0_label)s_idx",
     "uq": "%(table_name)s_%(column_0_name)s_key",
@@ -13,10 +17,9 @@ POSTGRES_INDEXES_NAMING_CONVENTION = {
     "pk": "%(table_name)s_pkey",
 }
 
-DATABASE_URL = "diosvo:1234@localhost/sg_rovers"
-SQLALCHEMY_DATABASE_URL = f"postgresql://{DATABASE_URL}"
+DATABASE_DSN = settings.database_dsn
 
-engine = create_engine(SQLALCHEMY_DATABASE_URL)
+engine = create_engine(DATABASE_DSN)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 metadata = MetaData(naming_convention=POSTGRES_INDEXES_NAMING_CONVENTION)
 

--- a/server/src/logging_config.py
+++ b/server/src/logging_config.py
@@ -1,11 +1,32 @@
-import logging
+import logging.config
+from functools import lru_cache
 
 import yaml
 
 
+@lru_cache
 def setup_logging() -> logging.Logger:
-    with open("logging.yaml", "r") as f:
-        log_config = yaml.safe_load(f.read())
+    """
+    Configure the logging once, and other modules can import the logger from this module.
 
-    # Apply the logging configuration
-    logging.config.dictConfig(log_config)
+    e.g.
+
+    `another_module.py`
+
+    >>> from .logging_config import logger
+    >>> logger.info(<message>)
+    """
+    with open("logging.yaml", "r") as f:
+        # Load the configuration only once using `lru_cache`.
+        log_config = yaml.safe_load(f.read())
+        logging.config.dictConfig(log_config)
+
+    logger = logging.getLogger()
+    logger.info("🌊 Setup logging successfully.")
+
+    return logger
+
+
+# Call `get_logger` at the module level,
+# so that the configuration is done when the module is imported.
+logger = setup_logging()

--- a/server/src/main.py
+++ b/server/src/main.py
@@ -2,29 +2,28 @@
 The root of the project, which inits the FastAPI application.
 """
 
-import logging
 from contextlib import asynccontextmanager
 
 from fastapi import APIRouter, FastAPI
-from starlette.config import Config
 
+from .config import get_settings
 from .database import engine, metadata
 from .exceptions import exception_handlers
-from .logging_config import setup_logging
+from .logging_config import logger
 
-# Setup logging configuration at the start
-setup_logging()
+# Read .env values
+settings = get_settings()
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     metadata.create_all(bind=engine)
-    logging.info("Connected to database.")
+    logger.info("🛢️  Connected to database.")
 
     try:
         yield
     finally:
-        logging.error("Database connection failed.")
+        logger.error("🛢️  Database connection failed.")
 
 
 """Metadata and Docs URLs
@@ -34,14 +33,13 @@ Hide docs by default. Show it explicitly on the selected envs only.
 References:
 - https://fastapi.tiangolo.com/tutorial/metadata/
 """
-config = Config(".env")
-ENVIRONMENT = config("ENVIRONMENT")
-SHOW_DOCS_ENVIRONMENT = "dev"
 
 TAGS_METADATA = [
     {"name": "<TAG_NAME>", "description": "<description>"},
 ]
-openapi_tags = TAGS_METADATA if ENVIRONMENT in SHOW_DOCS_ENVIRONMENT else None
+openapi_tags = (
+    TAGS_METADATA if settings.environment in settings.show_docs_environment else None
+)
 
 app = FastAPI(
     title="Saigon Rovers Basketball Club",


### PR DESCRIPTION
#### New ✨

- Configure a class to load values from the `.env` file and ensure it is only called at the application's start.

#### Improvements 🙌

- Adjust the logging config so that it can be used globally. Other modules can import `logger` via the `logging_config` module.

_Resolve #19_
