### PR TITLE
Unit testing for `asset` in db/action

### DIFF
--- a/src/actions/asset.test.ts
+++ b/src/actions/asset.test.ts
@@ -1,0 +1,223 @@
+import { vi } from 'vitest';
+
+import { revalidate } from '@/actions/cache';
+import {
+  deleteAsset,
+  getAssets as getDbAssets,
+  insertAsset as insertDbAsset,
+  updateAsset as updateDbAsset,
+} from '@/db/asset';
+import { getDbErrorMessage } from '@/db/pg-error';
+
+import { MOCK_ASSET, MOCK_ASSET_INPUT } from '@/test/mocks/asset';
+import { mockWithAuth } from '@/test/mocks/auth';
+import { MOCK_TEAM } from '@/test/mocks/team';
+
+import { getAssets, removeAsset, upsertAsset } from './asset';
+
+vi.mock('./auth', () => ({
+  withAuth: mockWithAuth,
+}));
+
+vi.mock('@/db/asset', () => ({
+  getAssets: vi.fn(),
+  insertAsset: vi.fn(),
+  updateAsset: vi.fn(),
+  deleteAsset: vi.fn(),
+}));
+
+vi.mock('@/actions/cache', () => ({
+  revalidate: {
+    assets: vi.fn(),
+  },
+}));
+
+const MOCK_ASSETS_RESPONSE = {
+  stats: {
+    total_items: 1,
+    need_replacement: 0,
+  },
+  data: [MOCK_ASSET],
+};
+
+describe('Asset Actions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const mockResult = {
+    rows: [],
+    rowCount: 1,
+    oid: 0,
+    fields: [],
+  };
+
+  describe('getAssets', () => {
+    test('calls getAssets with team_id', async () => {
+      vi.mocked(getDbAssets).mockResolvedValue(MOCK_ASSETS_RESPONSE);
+
+      const result = await getAssets();
+
+      expect(getDbAssets).toHaveBeenCalledWith(MOCK_TEAM.team_id);
+      expect(result).toEqual(MOCK_ASSETS_RESPONSE);
+    });
+
+    test('returns empty response when no assets exist', async () => {
+      const emptyResponse = {
+        stats: { total_items: 0, need_replacement: 0 },
+        data: [],
+      };
+      vi.mocked(getDbAssets).mockResolvedValue(emptyResponse);
+
+      const result = await getAssets();
+      expect(result).toEqual(emptyResponse);
+    });
+
+    test('propagates errors from getAssets', async () => {
+      const message = 'Database error';
+      const error = new Error(message);
+      vi.mocked(getDbAssets).mockRejectedValue(error);
+
+      await expect(getAssets()).rejects.toThrow(message);
+    });
+  });
+
+  describe('upsertAsset', () => {
+    test('updates existing asset and revalidates cache', async () => {
+      vi.mocked(updateDbAsset).mockResolvedValue({
+        ...mockResult,
+        command: 'UPDATE',
+      });
+
+      const result = await upsertAsset(MOCK_ASSET.asset_id, MOCK_ASSET_INPUT);
+
+      expect(updateDbAsset).toHaveBeenCalledWith(MOCK_ASSET.asset_id, {
+        ...MOCK_ASSET_INPUT,
+        team_id: MOCK_TEAM.team_id,
+      });
+      expect(insertDbAsset).not.toHaveBeenCalled();
+      expect(revalidate.assets).toHaveBeenCalled();
+      expect(result).toEqual({
+        success: true,
+        message: 'Updated asset successfully',
+      });
+    });
+
+    test('inserts new asset when asset_id is empty', async () => {
+      vi.mocked(insertDbAsset).mockResolvedValue({
+        ...mockResult,
+        command: 'INSERT',
+      });
+
+      const result = await upsertAsset('', MOCK_ASSET_INPUT);
+
+      expect(insertDbAsset).toHaveBeenCalledWith({
+        ...MOCK_ASSET_INPUT,
+        team_id: MOCK_TEAM.team_id,
+      });
+      expect(updateDbAsset).not.toHaveBeenCalled();
+      expect(revalidate.assets).toHaveBeenCalled();
+      expect(result).toEqual({
+        success: true,
+        message: 'Added asset successfully',
+      });
+    });
+
+    test('returns error response when update fails', async () => {
+      const errorMessage = 'Update failed';
+      vi.mocked(updateDbAsset).mockRejectedValue(new Error(errorMessage));
+      vi.mocked(getDbErrorMessage).mockReturnValue({
+        message: errorMessage,
+        constraint: null,
+      });
+
+      const result = await upsertAsset(MOCK_ASSET.asset_id, MOCK_ASSET_INPUT);
+
+      expect(getDbErrorMessage).toHaveBeenCalled();
+      expect(revalidate.assets).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        success: false,
+        message: errorMessage,
+      });
+    });
+
+    test('returns error response when insert fails', async () => {
+      const errorMessage = 'Insert failed';
+      vi.mocked(insertDbAsset).mockRejectedValue(new Error(errorMessage));
+      vi.mocked(getDbErrorMessage).mockReturnValue({
+        message: errorMessage,
+        constraint: null,
+      });
+
+      const result = await upsertAsset('', MOCK_ASSET_INPUT);
+
+      expect(getDbErrorMessage).toHaveBeenCalled();
+      expect(revalidate.assets).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        success: false,
+        message: errorMessage,
+      });
+    });
+
+    test('handles database constraint errors', async () => {
+      const pgError = 'Unique constraint violation';
+      vi.mocked(updateDbAsset).mockRejectedValue({
+        code: '23505',
+        detail: 'Duplicate key',
+      });
+      vi.mocked(getDbErrorMessage).mockReturnValue({
+        message: pgError,
+        constraint: 'unique_asset_name',
+      });
+
+      const result = await upsertAsset(MOCK_ASSET.asset_id, MOCK_ASSET_INPUT);
+
+      expect(result).toEqual({
+        success: false,
+        message: pgError,
+      });
+    });
+  });
+
+  describe('removeAsset', () => {
+    test('deletes asset successfully and revalidates cache', async () => {
+      vi.mocked(deleteAsset).mockResolvedValue({
+        ...mockResult,
+        command: 'DELETE',
+      });
+
+      const result = await removeAsset(MOCK_ASSET.asset_id);
+
+      expect(deleteAsset).toHaveBeenCalledWith(MOCK_ASSET.asset_id);
+      expect(revalidate.assets).toHaveBeenCalled();
+      expect(result).toEqual({
+        success: true,
+        message: 'Asset deleted successfully',
+      });
+    });
+
+    test('returns error response when delete fails', async () => {
+      vi.mocked(deleteAsset).mockRejectedValue(new Error('Delete failed'));
+
+      const result = await removeAsset(MOCK_ASSET.asset_id);
+
+      expect(deleteAsset).toHaveBeenCalledWith(MOCK_ASSET.asset_id);
+      expect(revalidate.assets).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        success: false,
+        message: 'Failed to delete asset',
+      });
+    });
+
+    test('handles non-error exceptions', async () => {
+      vi.mocked(deleteAsset).mockRejectedValue('Unknown error');
+
+      const result = await removeAsset(MOCK_ASSET.asset_id);
+
+      expect(result).toEqual({
+        success: false,
+        message: 'Failed to delete asset',
+      });
+    });
+  });
+});

--- a/src/db/asset.test.ts
+++ b/src/db/asset.test.ts
@@ -1,0 +1,208 @@
+import { desc, eq } from 'drizzle-orm';
+import { cacheTag } from 'next/cache';
+
+import db from '@/drizzle';
+import { AssetTable, InsertAsset } from '@/drizzle/schema/asset';
+
+import { getCacheTag } from '@/actions/cache';
+
+import {
+  mockDeleteFailure,
+  mockDeleteSuccess,
+  mockInsertFailure,
+  mockInsertSuccess,
+  mockUpdateFailure,
+  mockUpdateSuccess,
+} from '@/test/db-operations';
+import {
+  MOCK_ASSET,
+  MOCK_ASSET_INPUT,
+  MOCK_ASSET_STATS,
+} from '@/test/mocks/asset';
+import { MOCK_TEAM } from '@/test/mocks/team';
+
+import { deleteAsset, getAssets, insertAsset, updateAsset } from './asset';
+
+vi.mock('@/drizzle', () => ({
+  default: {
+    query: {
+      AssetTable: {
+        findMany: vi.fn(),
+      },
+    },
+    insert: vi.fn(() => ({
+      values: vi.fn(),
+    })),
+    update: vi.fn(() => ({
+      set: vi.fn(() => ({
+        where: vi.fn(),
+      })),
+    })),
+    delete: vi.fn(() => ({
+      where: vi.fn(),
+    })),
+  },
+}));
+
+vi.mock('@/drizzle/schema/asset', () => ({
+  AssetTable: {
+    team_id: 'team_id',
+    asset_id: 'asset_id',
+    condition: 'condition',
+  },
+}));
+
+vi.mock('@/actions/cache', () => ({
+  getCacheTag: {
+    assets: vi.fn(() => 'assets'),
+  },
+}));
+
+describe('getAssets', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('returns assets with stats when database query succeeds', async () => {
+    vi.mocked(db.query.AssetTable.findMany).mockResolvedValue([MOCK_ASSET]);
+
+    const result = await getAssets(MOCK_TEAM.team_id);
+
+    expect(result).toEqual({
+      stats: MOCK_ASSET_STATS,
+      data: [MOCK_ASSET],
+    });
+    expect(cacheTag).toHaveBeenCalledWith('assets');
+    expect(getCacheTag.assets).toHaveBeenCalled();
+    // Verify query construction
+    expect(eq).toHaveBeenCalledWith(AssetTable.team_id, MOCK_TEAM.team_id);
+    expect(desc).toHaveBeenCalledWith(AssetTable.updated_at);
+    expect(db.query.AssetTable.findMany).toHaveBeenCalledWith({
+      where: {
+        field: AssetTable.team_id,
+        value: MOCK_TEAM.team_id,
+        type: 'eq',
+      },
+      orderBy: { field: AssetTable.updated_at, direction: 'desc' },
+    });
+  });
+
+  test.each([
+    {
+      description: 'fails',
+      mockError: new Error('Database error'),
+    },
+    {
+      description: 'throws non-error exceptions',
+      mockError: 'Unknown error',
+    },
+  ])(
+    'returns default stats when database query $description',
+    async ({ mockError }) => {
+      vi.mocked(db.query.AssetTable.findMany).mockRejectedValue(mockError);
+
+      const result = await getAssets(MOCK_TEAM.team_id);
+      expect(result).toEqual({
+        stats: { total_items: 0, need_replacement: 0 },
+        data: [],
+      });
+    },
+  );
+});
+
+describe('insertAsset', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const mockInsertData: InsertAsset = {
+    team_id: MOCK_TEAM.team_id,
+    ...MOCK_ASSET_INPUT,
+  };
+
+  test('inserts asset successfully', async () => {
+    const mockValues = mockInsertSuccess({ asset_id: MOCK_ASSET.asset_id });
+
+    const result = await insertAsset(mockInsertData);
+
+    expect(result).toEqual({ asset_id: MOCK_ASSET.asset_id });
+    // Verify query construction
+    expect(db.insert).toHaveBeenCalledWith(AssetTable);
+    expect(mockValues).toHaveBeenCalledWith(mockInsertData);
+  });
+
+  test('throws error when insert fails', async () => {
+    const message = 'Insert failed';
+    mockInsertFailure(message);
+
+    await expect(insertAsset(mockInsertData)).rejects.toThrow(message);
+  });
+});
+
+describe('updateAsset', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const updatedAsset: InsertAsset = {
+    team_id: MOCK_TEAM.team_id,
+    ...MOCK_ASSET_INPUT,
+  };
+
+  test('updates asset successfully', async () => {
+    const { mockWhere, mockSet } = mockUpdateSuccess({
+      asset_id: MOCK_ASSET.asset_id,
+    });
+
+    const result = await updateAsset(MOCK_ASSET.asset_id, updatedAsset);
+
+    expect(result).toEqual({ asset_id: MOCK_ASSET.asset_id });
+    // Verify query construction
+    expect(db.update).toHaveBeenCalledWith(AssetTable);
+    expect(mockSet).toHaveBeenCalledWith(updatedAsset);
+    expect(eq).toHaveBeenCalledWith(AssetTable.asset_id, MOCK_ASSET.asset_id);
+    expect(mockWhere).toHaveBeenCalledWith({
+      field: AssetTable.asset_id,
+      value: MOCK_ASSET.asset_id,
+      type: 'eq',
+    });
+  });
+
+  test('throws error when update fails', async () => {
+    const message = 'Update failed';
+    mockUpdateFailure(message);
+
+    await expect(
+      updateAsset(MOCK_ASSET.asset_id, updatedAsset),
+    ).rejects.toThrow(message);
+  });
+});
+
+describe('deleteAsset', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('deletes asset successfully', async () => {
+    const mockWhere = mockDeleteSuccess({ asset_id: MOCK_ASSET.asset_id });
+
+    const result = await deleteAsset(MOCK_ASSET.asset_id);
+
+    expect(result).toEqual({ asset_id: MOCK_ASSET.asset_id });
+    // Verify query construction
+    expect(db.delete).toHaveBeenCalledWith(AssetTable);
+    expect(eq).toHaveBeenCalledWith(AssetTable.asset_id, MOCK_ASSET.asset_id);
+    expect(mockWhere).toHaveBeenCalledWith({
+      field: AssetTable.asset_id,
+      value: MOCK_ASSET.asset_id,
+      type: 'eq',
+    });
+  });
+
+  test('throws error when delete fails', async () => {
+    const message = 'Delete failed';
+    mockDeleteFailure(message);
+
+    await expect(deleteAsset(MOCK_ASSET.asset_id)).rejects.toThrow(message);
+  });
+});

--- a/src/db/asset.ts
+++ b/src/db/asset.ts
@@ -13,11 +13,10 @@ export async function getAssets(team_id: string) {
   cacheTag(getCacheTag.assets());
 
   try {
-    const assets = await db
-      .select()
-      .from(AssetTable)
-      .where(eq(AssetTable.team_id, team_id))
-      .orderBy(desc(AssetTable.updated_at));
+    const assets = await db.query.AssetTable.findMany({
+      where: eq(AssetTable.team_id, team_id),
+      orderBy: desc(AssetTable.updated_at),
+    });
 
     const stats = {
       total_items: assets.reduce((sum, asset) => sum + asset.quantity, 0),
@@ -38,21 +37,9 @@ export async function getAssets(team_id: string) {
   }
 }
 
-export async function getAsset(asset_id: string) {
-  try {
-    return await db.query.AssetTable.findFirst({
-      where: eq(AssetTable.asset_id, asset_id),
-    });
-  } catch {
-    return null;
-  }
-}
-
 export async function insertAsset(asset: InsertAsset) {
   try {
-    return await db.insert(AssetTable).values(asset).returning({
-      asset_id: AssetTable.asset_id,
-    });
+    return await db.insert(AssetTable).values(asset);
   } catch (error) {
     throw error;
   }
@@ -72,7 +59,7 @@ export async function updateAsset(asset_id: string, asset: InsertAsset) {
 export async function deleteAsset(asset_id: string) {
   try {
     return await db.delete(AssetTable).where(eq(AssetTable.asset_id, asset_id));
-  } catch {
-    return null;
+  } catch (error) {
+    throw error;
   }
 }

--- a/src/db/match.ts
+++ b/src/db/match.ts
@@ -1,4 +1,4 @@
-import { and, eq, gte, lte } from 'drizzle-orm';
+import { and, desc, eq, gte, lte } from 'drizzle-orm';
 
 import { DataWithStats } from '@/types/common';
 import { MatchStats, MatchWithTeams } from '@/types/match';
@@ -30,7 +30,7 @@ export async function getMatches(
         gte(MatchTable.date, start.toISOString()),
         lte(MatchTable.date, end.toISOString()),
       ),
-      orderBy: (matches, { desc }) => [desc(matches.created_at)],
+      orderBy: desc(MatchTable.updated_at),
     });
 
     const data = matches.map((match) => ({

--- a/src/db/rule.test.ts
+++ b/src/db/rule.test.ts
@@ -68,16 +68,17 @@ describe('getRule', () => {
     });
   });
 
-  test('returns null when database query fails', async () => {
-    const error = new Error('Database error');
-    vi.mocked(db.query.RuleTable.findFirst).mockRejectedValue(error);
-
-    const result = await getRule(MOCK_TEAM.team_id);
-    expect(result).toBeNull();
-  });
-
-  test('returns null when database query throws non-error exception', async () => {
-    vi.mocked(db.query.RuleTable.findFirst).mockRejectedValue('Unknown error');
+  test.each([
+    {
+      description: 'fails',
+      mockError: new Error('Database error'),
+    },
+    {
+      description: 'throws non-error exception',
+      mockError: 'Unknown error',
+    },
+  ])('returns null when database query $description', async ({ mockError }) => {
+    vi.mocked(db.query.RuleTable.findFirst).mockRejectedValue(mockError);
 
     const result = await getRule(MOCK_TEAM.team_id);
     expect(result).toBeNull();
@@ -126,6 +127,7 @@ describe('updateRule', () => {
     const result = await updateRule(MOCK_RULE.rule_id, newContent);
 
     expect(result).toEqual({ rule_id: 1 });
+    // Verify query construction
     expect(db.update).toHaveBeenCalledWith(RuleTable);
     expect(mockSet).toHaveBeenCalledWith({ content: newContent });
     expect(eq).toHaveBeenCalledWith(RuleTable.rule_id, MOCK_RULE.rule_id);

--- a/src/db/team.test.ts
+++ b/src/db/team.test.ts
@@ -53,18 +53,22 @@ describe('getOtherTeams', () => {
     });
   });
 
-  test('returns empty array when database query fails', async () => {
-    const error = new Error('Database error');
-    vi.mocked(db.query.TeamTable.findMany).mockRejectedValue(error);
+  test.each([
+    {
+      description: 'fails',
+      mockError: new Error('Database error'),
+    },
+    {
+      description: 'throws non-error exception',
+      mockError: 'Duplicated Key',
+    },
+  ])(
+    'returns empty array when database query $description',
+    async ({ mockError }) => {
+      vi.mocked(db.query.TeamTable.findMany).mockRejectedValue(mockError);
 
-    const result = await getOtherTeams();
-    expect(result).toEqual([]);
-  });
-
-  test('returns empty array when database query throws non-error exception', async () => {
-    vi.mocked(db.query.TeamTable.findMany).mockRejectedValue('Duplicated Key');
-
-    const result = await getOtherTeams();
-    expect(result).toEqual([]);
-  });
+      const result = await getOtherTeams();
+      expect(result).toEqual([]);
+    },
+  );
 });

--- a/test/db-operations.ts
+++ b/test/db-operations.ts
@@ -2,7 +2,7 @@ import { vi } from 'vitest';
 
 import db from '@/drizzle';
 
-export function mockInsertSuccess(returnValue: any) {
+export function mockInsertSuccess(returnValue: unknown) {
   const mockValues = vi.fn().mockResolvedValue(returnValue);
   vi.mocked(db.insert).mockReturnValue({
     values: mockValues,
@@ -21,7 +21,7 @@ export function mockInsertFailure(errorMessage: string) {
   return mockValues;
 }
 
-export function mockUpdateSuccess(returnValue: any) {
+export function mockUpdateSuccess(returnValue: unknown) {
   const mockWhere = vi.fn().mockResolvedValue(returnValue);
   const mockSet = vi.fn().mockReturnValue({ where: mockWhere });
 
@@ -42,4 +42,23 @@ export function mockUpdateFailure(errorMessage: string) {
   } as unknown as ReturnType<typeof db.update>);
 
   return { mockWhere, mockSet };
+}
+
+export function mockDeleteSuccess(returnValue: unknown) {
+  const mockWhere = vi.fn().mockResolvedValue(returnValue);
+  vi.mocked(db.delete).mockReturnValue({
+    where: mockWhere,
+  } as unknown as ReturnType<typeof db.delete>);
+
+  return mockWhere;
+}
+
+export function mockDeleteFailure(errorMessage: string) {
+  const error = new Error(errorMessage);
+  const mockWhere = vi.fn().mockRejectedValue(error);
+  vi.mocked(db.delete).mockReturnValue({
+    where: mockWhere,
+  } as unknown as ReturnType<typeof db.delete>);
+
+  return mockWhere;
 }

--- a/test/mocks/asset.ts
+++ b/test/mocks/asset.ts
@@ -1,0 +1,31 @@
+import { Asset } from '@/drizzle/schema';
+
+import { UpsertAssetSchemaValues } from '@/schemas/asset';
+import { AssetCategory, AssetCondition } from '@/utils/enum';
+
+import { MOCK_TEAM } from './team';
+
+export const MOCK_ASSET_INPUT: UpsertAssetSchemaValues = {
+  name: 'Test Asset',
+  category: AssetCategory.EQUIPMENT,
+  quantity: 10,
+  condition: AssetCondition.GOOD,
+  note: undefined,
+};
+
+export const MOCK_ASSET: Asset = {
+  asset_id: 'asset-123',
+  team_id: MOCK_TEAM.team_id,
+  name: MOCK_ASSET_INPUT.name,
+  category: MOCK_ASSET_INPUT.category,
+  quantity: MOCK_ASSET_INPUT.quantity,
+  condition: MOCK_ASSET_INPUT.condition,
+  note: null,
+  created_at: new Date('2026-01-01'),
+  updated_at: new Date('2026-01-01'),
+};
+
+export const MOCK_ASSET_STATS = {
+  total_items: MOCK_ASSET.quantity,
+  need_replacement: 0,
+};

--- a/test/setup/third-parties.ts
+++ b/test/setup/third-parties.ts
@@ -7,5 +7,6 @@ vi.mock('nuqs', async () => {
 });
 
 vi.mock('drizzle-orm', () => ({
+  desc: vi.fn((field) => ({ field, direction: 'desc' })),
   eq: vi.fn((field, value) => ({ field, value, type: 'eq' })),
 }));


### PR DESCRIPTION
#### New ✨

- Added unit tests for `asset` in db/ actions

#### Improvements 🙌

- Refactored asset database functions to use the query builder pattern and improved error handling.
- Enhanced test infrastructure with mock delete operations and additional drizzle-orm mocks
- Removed the unused `getAsset` function.
- Updated match query to use simplified `orderBy` syntax.

_Resolve #133_