### PR TITLE
Unit testing for cache revalidation

### DIFF
--- a/src/actions/cache.test.ts
+++ b/src/actions/cache.test.ts
@@ -1,0 +1,49 @@
+import { revalidatePath, revalidateTag } from 'next/cache';
+
+import { MOCK_USER } from '@/test/mocks/user';
+import { CACHE_TAG } from '@/utils/constant';
+
+import { revalidate } from './cache';
+
+describe('revalidate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Cached entities (revalidatePath + revalidateTag)', () => {
+    test.each([
+      ['assets', '/assets', CACHE_TAG.ASSETS],
+      ['leagues', '/leagues', CACHE_TAG.LEAGUES],
+      ['locations', '/locations', CACHE_TAG.LOCATIONS],
+      ['rule', '/team-rule', CACHE_TAG.RULE],
+    ] as const)('revalidate %s() correctly', (method, path, tag) => {
+      revalidate[method]();
+
+      expect(revalidatePath).toHaveBeenCalledWith(path);
+      expect(revalidateTag).toHaveBeenCalledWith(tag, 'max');
+    });
+  });
+
+  describe('Non-cached entities (revalidatePath only)', () => {
+    test.each([
+      ['attendances', '/attendance'],
+      ['matches', '/matches'],
+      ['roster', '/roster'],
+      ['sessions', '/training'],
+      ['testResults', '/periodic-testing'],
+      ['testTypes', '/periodic-testing/test-types'],
+    ] as const)('revalidate %s() correctly', (method, path) => {
+      revalidate[method]();
+
+      expect(revalidatePath).toHaveBeenCalledWith(path);
+      expect(revalidateTag).not.toHaveBeenCalled();
+    });
+
+    test('user() calls revalidatePath with the correct profile path', () => {
+      revalidate.user(MOCK_USER.id);
+
+      expect(revalidatePath).toHaveBeenCalledWith('/profile/' + MOCK_USER.id);
+      expect(revalidateTag).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/test/setup/next.ts
+++ b/test/setup/next.ts
@@ -74,4 +74,6 @@ vi.mock('next/link', () => ({
 
 vi.mock('next/cache', () => ({
   cacheTag: vi.fn(),
+  revalidatePath: vi.fn(),
+  revalidateTag: vi.fn(),
 }));


### PR DESCRIPTION
#### New ✨

- Add a dedicated unit test suite validating `revalidate.*()` calls for all supported entities.

#### Improvements 🙌

- Extend the global Next.js test mocks to include `revalidatePath` and `revalidateTag`.

_Resolve #159_
