### PR TITLE
Unit testing for `training-sessions` in db/action

### DIFF
--- a/src/actions/training-session.test.ts
+++ b/src/actions/training-session.test.ts
@@ -1,0 +1,285 @@
+import { revalidate } from '@/actions/cache';
+import { getDbErrorMessage } from '@/db/pg-error';
+import {
+  deleteSession,
+  getSessions as getDbSessions,
+  insertSession,
+  updateSession,
+} from '@/db/training-session';
+import { getTeamHeadCoach } from '@/db/user';
+import { UpsertSessionSchemaValues } from '@/schemas/training';
+
+import { mockWithAuth } from '@/test/mocks/auth';
+import { MOCK_TEAM } from '@/test/mocks/team';
+import {
+  MOCK_TRAINING_SESSION,
+  MOCK_TRAINING_SESSION_INPUT,
+  MOCK_TRAINING_SESSION_RESPONSE,
+} from '@/test/mocks/training-sessions';
+import { MOCK_COACH_WITH_NAME } from '@/test/mocks/user';
+
+import { Interval } from '@/utils/enum';
+import { TrainingSearchParams } from '@/utils/filters';
+
+import {
+  getCoach,
+  getSessions,
+  removeSession,
+  upsertSession,
+} from './training-session';
+
+vi.mock('./auth', () => ({
+  withAuth: mockWithAuth,
+}));
+
+vi.mock('@/db/training-session', () => ({
+  getSessions: vi.fn(),
+  insertSession: vi.fn(),
+  updateSession: vi.fn(),
+  deleteSession: vi.fn(),
+}));
+
+vi.mock('@/db/user', () => ({
+  getTeamHeadCoach: vi.fn(),
+}));
+
+vi.mock('@/actions/cache', () => ({
+  revalidate: {
+    sessions: vi.fn(),
+  },
+}));
+
+const MOCK_SESSION_ID = MOCK_TRAINING_SESSION.session_id;
+
+describe('Training Session Actions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getCoach', () => {
+    test('returns head coach for the team', async () => {
+      vi.mocked(getTeamHeadCoach).mockResolvedValue(MOCK_COACH_WITH_NAME);
+
+      const result = await getCoach();
+
+      expect(getTeamHeadCoach).toHaveBeenCalled();
+      expect(result).toEqual(MOCK_COACH_WITH_NAME);
+    });
+
+    test('returns null when no coach is assigned', async () => {
+      vi.mocked(getTeamHeadCoach).mockResolvedValue(null);
+
+      const result = await getCoach();
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('getSessions', () => {
+    const mockParams: TrainingSearchParams = {
+      interval: Interval.THIS_MONTH,
+      status: 'all',
+      page: 1,
+      q: '',
+    };
+
+    test('calls getSessions with params', async () => {
+      vi.mocked(getDbSessions).mockResolvedValue(
+        MOCK_TRAINING_SESSION_RESPONSE,
+      );
+
+      const result = await getSessions(mockParams);
+
+      expect(getDbSessions).toHaveBeenCalledWith(MOCK_TEAM.team_id, mockParams);
+      expect(result).toEqual(MOCK_TRAINING_SESSION_RESPONSE);
+    });
+
+    test('returns empty response when no sessions exist', async () => {
+      const emptyResponse = {
+        data: [],
+        stats: {
+          completed_sessions: 0,
+          avg_attendance: 0,
+          total_hours: 0,
+        },
+      };
+      vi.mocked(getDbSessions).mockResolvedValue(emptyResponse);
+
+      const result = await getSessions(mockParams);
+
+      expect(result).toEqual(emptyResponse);
+    });
+
+    test('propagates errors from getSessions', async () => {
+      const message = 'Database error';
+      vi.mocked(getDbSessions).mockRejectedValue(new Error(message));
+
+      await expect(getSessions(mockParams)).rejects.toThrow(message);
+    });
+  });
+
+  describe('upsertSession', () => {
+    const sessionData: UpsertSessionSchemaValues = {
+      date: MOCK_TRAINING_SESSION_INPUT.date,
+      start_time: MOCK_TRAINING_SESSION_INPUT.start_time,
+      end_time: MOCK_TRAINING_SESSION_INPUT.end_time,
+      location_id: MOCK_TRAINING_SESSION_INPUT.location_id,
+      status: MOCK_TRAINING_SESSION_INPUT.status!,
+    };
+
+    test('updates existing session and revalidates cache', async () => {
+      vi.mocked(getTeamHeadCoach).mockResolvedValue(MOCK_COACH_WITH_NAME);
+      vi.mocked(updateSession).mockResolvedValue([MOCK_TRAINING_SESSION]);
+
+      const result = await upsertSession(MOCK_SESSION_ID, sessionData);
+
+      expect(updateSession).toHaveBeenCalledWith(MOCK_SESSION_ID, sessionData);
+      expect(insertSession).not.toHaveBeenCalled();
+      expect(revalidate.sessions).toHaveBeenCalled();
+      expect(result).toEqual({
+        success: true,
+        message: 'Updated training session successfully',
+      });
+    });
+
+    test('inserts new session when session_id is empty', async () => {
+      vi.mocked(getTeamHeadCoach).mockResolvedValue(MOCK_COACH_WITH_NAME);
+      vi.mocked(insertSession).mockResolvedValue([MOCK_TRAINING_SESSION]);
+
+      const result = await upsertSession('', sessionData);
+
+      expect(insertSession).toHaveBeenCalledWith({
+        ...sessionData,
+        team_id: MOCK_TRAINING_SESSION_INPUT.team_id,
+        coach_id: MOCK_COACH_WITH_NAME.id,
+      });
+      expect(updateSession).not.toHaveBeenCalled();
+      expect(revalidate.sessions).toHaveBeenCalled();
+      expect(result).toEqual({
+        success: true,
+        message: 'Created training session successfully',
+      });
+    });
+
+    test('returns error when no coach is assigned to the team', async () => {
+      vi.mocked(getTeamHeadCoach).mockResolvedValue(null);
+
+      const result = await upsertSession(MOCK_SESSION_ID, sessionData);
+
+      expect(insertSession).not.toHaveBeenCalled();
+      expect(updateSession).not.toHaveBeenCalled();
+      expect(revalidate.sessions).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        success: false,
+        message: 'No coach assigned to the team',
+      });
+    });
+
+    test('returns error response when update fails', async () => {
+      const errorMessage = 'Update failed';
+      vi.mocked(getTeamHeadCoach).mockResolvedValue(MOCK_COACH_WITH_NAME);
+      vi.mocked(updateSession).mockRejectedValue(new Error(errorMessage));
+      vi.mocked(getDbErrorMessage).mockReturnValue({
+        message: errorMessage,
+        constraint: null,
+      });
+
+      const result = await upsertSession(MOCK_SESSION_ID, sessionData);
+
+      expect(getDbErrorMessage).toHaveBeenCalled();
+      expect(revalidate.sessions).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        success: false,
+        message: errorMessage,
+      });
+    });
+
+    test('returns error response when insert fails', async () => {
+      const errorMessage = 'Insert failed';
+      vi.mocked(getTeamHeadCoach).mockResolvedValue(MOCK_COACH_WITH_NAME);
+      vi.mocked(insertSession).mockRejectedValue(new Error(errorMessage));
+      vi.mocked(getDbErrorMessage).mockReturnValue({
+        message: errorMessage,
+        constraint: null,
+      });
+
+      const result = await upsertSession('', sessionData);
+
+      expect(getDbErrorMessage).toHaveBeenCalled();
+      expect(revalidate.sessions).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        success: false,
+        message: errorMessage,
+      });
+    });
+
+    test('handles database constraint errors', async () => {
+      const pgError = 'Unique constraint violation';
+      vi.mocked(getTeamHeadCoach).mockResolvedValue(MOCK_COACH_WITH_NAME);
+      vi.mocked(updateSession).mockRejectedValue({
+        code: '23505',
+        detail: 'Duplicate key',
+      });
+      vi.mocked(getDbErrorMessage).mockReturnValue({
+        message: pgError,
+        constraint: 'unique_session_date',
+      });
+
+      const result = await upsertSession(MOCK_SESSION_ID, sessionData);
+
+      expect(result).toEqual({
+        success: false,
+        message: pgError,
+      });
+    });
+  });
+
+  describe('removeSession', () => {
+    test('deletes session successfully and revalidates cache', async () => {
+      vi.mocked(deleteSession).mockResolvedValue([MOCK_TRAINING_SESSION]);
+
+      const result = await removeSession(MOCK_SESSION_ID);
+
+      expect(deleteSession).toHaveBeenCalledWith(MOCK_SESSION_ID);
+      expect(revalidate.sessions).toHaveBeenCalled();
+      expect(result).toEqual({
+        success: true,
+        message: 'Training session deleted successfully',
+      });
+    });
+
+    test('returns error response with short id when delete fails', async () => {
+      const errorMessage = 'Delete failed';
+      vi.mocked(deleteSession).mockRejectedValue(new Error(errorMessage));
+      vi.mocked(getDbErrorMessage).mockReturnValue({
+        message: errorMessage,
+        constraint: null,
+      });
+
+      const result = await removeSession(MOCK_SESSION_ID);
+
+      expect(deleteSession).toHaveBeenCalledWith(MOCK_SESSION_ID);
+      expect(revalidate.sessions).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        success: false,
+        message: `${errorMessage} (id: ${MOCK_SESSION_ID.slice(0, 8)})`,
+      });
+    });
+
+    test('handles database constraint errors on delete', async () => {
+      const pgError = 'Foreign key constraint violation';
+      vi.mocked(deleteSession).mockRejectedValue({ code: '23503' });
+      vi.mocked(getDbErrorMessage).mockReturnValue({
+        message: pgError,
+        constraint: 'fk_session',
+      });
+
+      const result = await removeSession(MOCK_SESSION_ID);
+
+      expect(result).toEqual({
+        success: false,
+        message: `${pgError} (id: ${MOCK_SESSION_ID.slice(0, 8)})`,
+      });
+    });
+  });
+});

--- a/src/db/training-session.ts
+++ b/src/db/training-session.ts
@@ -41,9 +41,7 @@ export async function getSessions(
           columns: { name: true },
         },
         coach: {
-          columns: {
-            id: true,
-          },
+          columns: { id: true },
         },
         attendances: {
           columns: { attendance_id: true, status: true },

--- a/src/db/training-sessions.test.ts
+++ b/src/db/training-sessions.test.ts
@@ -1,0 +1,291 @@
+import { and, desc, eq, gte, lte } from 'drizzle-orm';
+
+import db from '@/drizzle';
+import { InsertTrainingSession, TrainingSessionTable } from '@/drizzle/schema';
+
+import { ALL } from '@/utils/constant';
+import { Interval, SessionStatus } from '@/utils/enum';
+import { TrainingSearchParams } from '@/utils/filters';
+import { TIME_DURATION } from '@/utils/formatter';
+
+import {
+  mockDeleteReturningFailure,
+  mockDeleteReturningSuccess,
+  mockInsertReturningFailure,
+  mockInsertReturningSuccess,
+  mockUpdateReturningFailure,
+  mockUpdateReturningSuccess,
+} from '@/test/db-operations';
+import { MOCK_TEAM } from '@/test/mocks/team';
+import {
+  MOCK_SESSIONS_DB_RESULT,
+  MOCK_TRAINING_SESSION,
+  MOCK_TRAINING_SESSION_INPUT,
+  MOCK_TRAINING_SESSION_RESPONSE,
+} from '@/test/mocks/training-sessions';
+
+import {
+  deleteSession,
+  getSessions,
+  insertSession,
+  updateSession,
+} from './training-session';
+
+vi.mock('@/drizzle', () => ({
+  default: {
+    query: {
+      TrainingSessionTable: {
+        findMany: vi.fn(),
+      },
+    },
+    insert: vi.fn(() => ({
+      values: vi.fn(() => ({
+        returning: vi.fn(),
+      })),
+    })),
+    update: vi.fn(() => ({
+      set: vi.fn(() => ({
+        where: vi.fn(() => ({
+          returning: vi.fn(),
+        })),
+      })),
+    })),
+    delete: vi.fn(() => ({
+      where: vi.fn(() => ({
+        returning: vi.fn(),
+      })),
+    })),
+  },
+}));
+
+vi.mock('@/drizzle/schema', () => ({
+  TrainingSessionTable: {
+    session_id: 'session_id',
+    team_id: 'team_id',
+    date: 'date',
+    start_time: 'start_time',
+    status: 'status',
+  },
+}));
+
+describe('getSessions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const mockParams: TrainingSearchParams = {
+    interval: Interval.THIS_MONTH,
+    status: ALL.value,
+    page: 1,
+    q: '',
+  };
+
+  test('returns sessions with stats when database query succeeds', async () => {
+    vi.mocked(db.query.TrainingSessionTable.findMany).mockResolvedValue(
+      MOCK_SESSIONS_DB_RESULT,
+    );
+
+    const result = await getSessions(MOCK_TEAM.team_id, mockParams);
+
+    const { start, end } = TIME_DURATION[mockParams.interval];
+
+    expect(result).toEqual(MOCK_TRAINING_SESSION_RESPONSE);
+    // Verify query construction
+    expect(db.query.TrainingSessionTable.findMany).toHaveBeenCalledWith({
+      where: and(
+        eq(TrainingSessionTable.team_id, MOCK_TEAM.team_id),
+        gte(TrainingSessionTable.date, start.toISOString()),
+        lte(TrainingSessionTable.date, end.toISOString()),
+      ),
+      with: {
+        location: { columns: { name: true } },
+        coach: { columns: { id: true } },
+        attendances: { columns: { attendance_id: true, status: true } },
+      },
+      orderBy: [
+        desc(TrainingSessionTable.date),
+        desc(TrainingSessionTable.start_time),
+      ],
+    });
+  });
+
+  test('applies status filter when status is not ALL', async () => {
+    vi.mocked(db.query.TrainingSessionTable.findMany).mockResolvedValue(
+      MOCK_SESSIONS_DB_RESULT,
+    );
+
+    const paramsWithStatus: TrainingSearchParams = {
+      ...mockParams,
+      status: SessionStatus.COMPLETED,
+    };
+
+    await getSessions(MOCK_TEAM.team_id, paramsWithStatus);
+
+    const { start, end } = TIME_DURATION[paramsWithStatus.interval];
+
+    expect(db.query.TrainingSessionTable.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: and(
+          eq(TrainingSessionTable.team_id, MOCK_TEAM.team_id),
+          gte(TrainingSessionTable.date, start.toISOString()),
+          lte(TrainingSessionTable.date, end.toISOString()),
+          eq(TrainingSessionTable.status, SessionStatus.COMPLETED),
+        ),
+      }),
+    );
+  });
+
+  test('returns empty stats when no sessions exist', async () => {
+    vi.mocked(db.query.TrainingSessionTable.findMany).mockResolvedValue([]);
+
+    const result = await getSessions(MOCK_TEAM.team_id, mockParams);
+
+    expect(result).toEqual({
+      data: [],
+      stats: {
+        completed_sessions: 0,
+        avg_attendance: 0,
+        total_hours: 0,
+      },
+    });
+  });
+
+  test.each([
+    {
+      description: 'fails',
+      mockError: new Error('Database error'),
+    },
+    {
+      description: 'throws non-error exception',
+      mockError: 'Unknown error',
+    },
+  ])(
+    'returns default stats when database query $description',
+    async ({ mockError }) => {
+      vi.mocked(db.query.TrainingSessionTable.findMany).mockRejectedValue(
+        mockError,
+      );
+
+      const result = await getSessions(MOCK_TEAM.team_id, mockParams);
+
+      expect(result).toEqual({
+        data: [],
+        stats: {
+          completed_sessions: 0,
+          avg_attendance: 0,
+          total_hours: 0,
+        },
+      });
+    },
+  );
+});
+
+describe('insertSession', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('inserts session successfully', async () => {
+    const { mockValues, mockReturning } = mockInsertReturningSuccess([
+      MOCK_TRAINING_SESSION,
+    ]);
+
+    const result = await insertSession(MOCK_TRAINING_SESSION_INPUT);
+
+    expect(result).toEqual([MOCK_TRAINING_SESSION]);
+    // Verify query construction
+    expect(db.insert).toHaveBeenCalledWith(TrainingSessionTable);
+    expect(mockValues).toHaveBeenCalledWith(MOCK_TRAINING_SESSION_INPUT);
+    expect(mockReturning).toHaveBeenCalled();
+  });
+
+  test('throws error when insert fails', async () => {
+    const message = 'Insert failed';
+    mockInsertReturningFailure(message);
+
+    await expect(insertSession({} as InsertTrainingSession)).rejects.toThrow(
+      message,
+    );
+  });
+});
+
+describe('updateSession', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('updates session successfully', async () => {
+    const { mockSet, mockWhere, mockReturning } = mockUpdateReturningSuccess([
+      MOCK_TRAINING_SESSION,
+    ]);
+
+    const result = await updateSession(
+      MOCK_TRAINING_SESSION.session_id,
+      MOCK_TRAINING_SESSION_INPUT,
+    );
+
+    expect(result).toEqual([MOCK_TRAINING_SESSION]);
+    // Verify query construction
+    expect(db.update).toHaveBeenCalledWith(TrainingSessionTable);
+    expect(mockSet).toHaveBeenCalledWith(MOCK_TRAINING_SESSION_INPUT);
+    expect(eq).toHaveBeenCalledWith(
+      TrainingSessionTable.session_id,
+      MOCK_TRAINING_SESSION.session_id,
+    );
+    expect(mockWhere).toHaveBeenCalledWith({
+      field: TrainingSessionTable.session_id,
+      value: MOCK_TRAINING_SESSION.session_id,
+      type: 'eq',
+    });
+    expect(mockReturning).toHaveBeenCalled();
+  });
+
+  test('throws error when update fails', async () => {
+    const message = 'Update failed';
+    mockUpdateReturningFailure(message);
+
+    await expect(
+      updateSession(
+        MOCK_TRAINING_SESSION.session_id,
+        MOCK_TRAINING_SESSION_INPUT,
+      ),
+    ).rejects.toThrow(message);
+  });
+});
+
+describe('deleteSession', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('deletes session successfully', async () => {
+    const { mockWhere, mockReturning } = mockDeleteReturningSuccess([
+      MOCK_TRAINING_SESSION,
+    ]);
+
+    const result = await deleteSession(MOCK_TRAINING_SESSION.session_id);
+
+    expect(result).toEqual([MOCK_TRAINING_SESSION]);
+    // Verify query construction
+    expect(db.delete).toHaveBeenCalledWith(TrainingSessionTable);
+    expect(eq).toHaveBeenCalledWith(
+      TrainingSessionTable.session_id,
+      MOCK_TRAINING_SESSION.session_id,
+    );
+    expect(mockWhere).toHaveBeenCalledWith({
+      field: TrainingSessionTable.session_id,
+      value: MOCK_TRAINING_SESSION.session_id,
+      type: 'eq',
+    });
+    expect(mockReturning).toHaveBeenCalled();
+  });
+
+  test('throws error when delete fails', async () => {
+    const message = 'Delete failed';
+    mockDeleteReturningFailure(message);
+
+    await expect(
+      deleteSession(MOCK_TRAINING_SESSION.session_id),
+    ).rejects.toThrow(message);
+  });
+});

--- a/test/db-operations.ts
+++ b/test/db-operations.ts
@@ -162,6 +162,29 @@ export function mockInsertFailure(errorMessage: string) {
   return mockValues;
 }
 
+export function mockInsertReturningSuccess(returnValue: unknown) {
+  const mockReturning = vi.fn().mockResolvedValue(returnValue);
+  const mockValues = vi.fn().mockReturnValue({ returning: mockReturning });
+
+  vi.mocked(db.insert).mockReturnValue({
+    values: mockValues,
+  } as unknown as ReturnType<typeof db.insert>);
+
+  return { mockValues, mockReturning };
+}
+
+export function mockInsertReturningFailure(errorMessage: string) {
+  const error = new Error(errorMessage);
+  const mockReturning = vi.fn().mockRejectedValue(error);
+  const mockValues = vi.fn().mockReturnValue({ returning: mockReturning });
+
+  vi.mocked(db.insert).mockReturnValue({
+    values: mockValues,
+  } as unknown as ReturnType<typeof db.insert>);
+
+  return { mockValues, mockReturning };
+}
+
 export function mockUpdateSuccess(returnValue: unknown) {
   const mockWhere = vi.fn().mockResolvedValue(returnValue);
   const mockSet = vi.fn().mockReturnValue({ where: mockWhere });
@@ -171,6 +194,18 @@ export function mockUpdateSuccess(returnValue: unknown) {
   } as unknown as ReturnType<typeof db.update>);
 
   return { mockWhere, mockSet };
+}
+
+export function mockUpdateReturningSuccess(returnValue: unknown) {
+  const mockReturning = vi.fn().mockResolvedValue(returnValue);
+  const mockWhere = vi.fn().mockReturnValue({ returning: mockReturning });
+  const mockSet = vi.fn().mockReturnValue({ where: mockWhere });
+
+  vi.mocked(db.update).mockReturnValue({
+    set: mockSet,
+  } as unknown as ReturnType<typeof db.update>);
+
+  return { mockSet, mockWhere, mockReturning };
 }
 
 export function mockUpdateFailure(errorMessage: string) {
@@ -185,6 +220,19 @@ export function mockUpdateFailure(errorMessage: string) {
   return { mockWhere, mockSet };
 }
 
+export function mockUpdateReturningFailure(errorMessage: string) {
+  const error = new Error(errorMessage);
+  const mockReturning = vi.fn().mockRejectedValue(error);
+  const mockWhere = vi.fn().mockReturnValue({ returning: mockReturning });
+  const mockSet = vi.fn().mockReturnValue({ where: mockWhere });
+
+  vi.mocked(db.update).mockReturnValue({
+    set: mockSet,
+  } as unknown as ReturnType<typeof db.update>);
+
+  return { mockSet, mockWhere, mockReturning };
+}
+
 export function mockDeleteSuccess(returnValue: unknown) {
   const mockWhere = vi.fn().mockResolvedValue(returnValue);
   vi.mocked(db.delete).mockReturnValue({
@@ -194,12 +242,36 @@ export function mockDeleteSuccess(returnValue: unknown) {
   return mockWhere;
 }
 
+export function mockDeleteReturningSuccess(returnValue: unknown) {
+  const mockReturning = vi.fn().mockResolvedValue(returnValue);
+  const mockWhere = vi.fn().mockReturnValue({ returning: mockReturning });
+
+  vi.mocked(db.delete).mockReturnValue({
+    where: mockWhere,
+  } as unknown as ReturnType<typeof db.delete>);
+
+  return { mockWhere, mockReturning };
+}
+
 export function mockDeleteFailure(errorMessage: string) {
   const error = new Error(errorMessage);
   const mockWhere = vi.fn().mockRejectedValue(error);
+
   vi.mocked(db.delete).mockReturnValue({
     where: mockWhere,
   } as unknown as ReturnType<typeof db.delete>);
 
   return mockWhere;
+}
+
+export function mockDeleteReturningFailure(errorMessage: string) {
+  const error = new Error(errorMessage);
+  const mockReturning = vi.fn().mockRejectedValue(error);
+  const mockWhere = vi.fn().mockReturnValue({ returning: mockReturning });
+
+  vi.mocked(db.delete).mockReturnValue({
+    where: mockWhere,
+  } as unknown as ReturnType<typeof db.delete>);
+
+  return { mockWhere, mockReturning };
 }

--- a/test/mocks/training-sessions.ts
+++ b/test/mocks/training-sessions.ts
@@ -1,0 +1,86 @@
+import { InsertTrainingSession, TrainingSession } from '@/drizzle/schema';
+
+import { AttendanceStatus, SessionStatus } from '@/utils/enum';
+
+import { MOCK_LOCATION } from './location';
+import { MOCK_TEAM } from './team';
+import { MOCK_COACH } from './user';
+
+export const MOCK_TRAINING_SESSION_INPUT: InsertTrainingSession = {
+  team_id: MOCK_TEAM.team_id,
+  coach_id: MOCK_COACH.id,
+  location_id: MOCK_LOCATION.location_id,
+  date: '2026-12-12',
+  start_time: '09:00:00',
+  end_time: '11:00:00',
+  status: SessionStatus.COMPLETED,
+};
+
+export const MOCK_TRAINING_SESSION: TrainingSession = {
+  ...(MOCK_TRAINING_SESSION_INPUT as TrainingSession),
+  session_id: 'session-123',
+  created_at: new Date('2026-01-01'),
+  updated_at: new Date('2026-01-01'),
+};
+
+// Sessions with relationships (for db layer with 'with' queries)
+const createSessionWithDetails = (
+  id: string,
+  status: SessionStatus,
+  startTime: string,
+  endTime: string,
+  attendances: Array<{ attendance_id: string; status: AttendanceStatus }>,
+) => ({
+  ...MOCK_TRAINING_SESSION,
+  session_id: id,
+  status,
+  start_time: startTime,
+  end_time: endTime,
+  location: { name: MOCK_LOCATION.name },
+  coach: { id: MOCK_COACH.id },
+  attendances,
+});
+
+export const MOCK_SESSIONS_DB_RESULT = [
+  createSessionWithDetails(
+    'session-1',
+    SessionStatus.COMPLETED,
+    '09:00:00',
+    '11:00:00',
+    [
+      { attendance_id: 'att-1', status: AttendanceStatus.ON_TIME },
+      { attendance_id: 'att-2', status: AttendanceStatus.LATE },
+      { attendance_id: 'att-3', status: AttendanceStatus.ABSENT },
+    ],
+  ),
+  createSessionWithDetails(
+    'session-2',
+    SessionStatus.SCHEDULED,
+    '10:00:00',
+    '12:00:00',
+    [
+      { attendance_id: 'att-4', status: AttendanceStatus.ON_TIME },
+      { attendance_id: 'att-5', status: AttendanceStatus.ON_TIME },
+    ],
+  ),
+];
+
+export const MOCK_TRAINING_SESSION_RESPONSE = {
+  data: [
+    {
+      ...MOCK_SESSIONS_DB_RESULT[0],
+      attendance_count: 3,
+      present_rate: '2/3 · 67.0%',
+    },
+    {
+      ...MOCK_SESSIONS_DB_RESULT[1],
+      attendance_count: 2,
+      present_rate: '2/2 · 100.0%',
+    },
+  ],
+  stats: {
+    completed_sessions: 1,
+    avg_attendance: 2.5,
+    total_hours: 4,
+  },
+};

--- a/test/mocks/user.ts
+++ b/test/mocks/user.ts
@@ -53,6 +53,11 @@ export const MOCK_COACH: Coach = {
   updated_at: new Date('2026-01-01'),
 };
 
+export const MOCK_COACH_WITH_NAME: Coach & { name: string } = {
+  ...MOCK_COACH,
+  name: MOCK_USER_INPUT.name,
+};
+
 export const MOCK_USER_WITH_PLAYER = {
   ...MOCK_USER,
   player: MOCK_PLAYER,


### PR DESCRIPTION
#### New ✨

- Adds unit test coverage for the `training-sessions` db layer and server actions, along with supporting test mocks/helpers to exercise Drizzle `.returning()` flows.

_Resolve #158_
