### PR TITLE
Unit testing for shared components 

### DIFF
--- a/src/components/common/LocationSelection.test.tsx
+++ b/src/components/common/LocationSelection.test.tsx
@@ -51,7 +51,6 @@ describe('LocationSelection', () => {
 
   test('renders with label', async () => {
     setup();
-    await waitFor(() => expect(mockGetLocations).toHaveBeenCalled());
 
     expect(screen.getByText(/Select locations/i)).toBeInTheDocument();
   });
@@ -62,7 +61,7 @@ describe('LocationSelection', () => {
     await user.click(placeholder);
 
     expect(await screen.findByText(MOCK_LOCATION.name)).toBeInTheDocument();
-    expect(screen.getByText(MOCK_LOCATION.name)).toBeInTheDocument();
+    expect(screen.getByText(MOCK_LOCATION_2.name)).toBeInTheDocument();
   });
 
   test('renders location address under the name', async () => {

--- a/src/components/common/LocationSelection.test.tsx
+++ b/src/components/common/LocationSelection.test.tsx
@@ -1,0 +1,130 @@
+import { axe } from 'jest-axe';
+import { useForm } from 'react-hook-form';
+import { SWRConfig } from 'swr';
+
+import { MOCK_LOCATION, MOCK_LOCATION_2 } from '@/test/mocks/location';
+import { renderWithUI, screen, waitFor } from '@/test/utilities';
+
+import { getLocations } from '@/actions/location';
+import LocationSelection from './LocationSelection';
+
+vi.mock('@/actions/location', () => ({
+  getLocations: vi.fn(),
+}));
+
+const withFreshSWR = (ui: React.ReactElement) => (
+  <SWRConfig value={{ provider: () => new Map() }}>{ui}</SWRConfig>
+);
+
+type FormValues = { location_id: Nullable<string> };
+
+const TestForm = ({ isDisabled = false }: { isDisabled?: boolean }) => {
+  const { control } = useForm<FormValues>({
+    defaultValues: { location_id: null },
+  });
+  return <LocationSelection control={control} isDisabled={isDisabled} />;
+};
+
+describe('LocationSelection', () => {
+  const mockGetLocations = vi.mocked(getLocations);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetLocations.mockResolvedValue([MOCK_LOCATION, MOCK_LOCATION_2]);
+  });
+
+  const setup = async (overrides: { isDisabled?: boolean } = {}) => {
+    const component = renderWithUI(withFreshSWR(<TestForm {...overrides} />));
+    const placeholder = screen.getByPlaceholderText('Type to search');
+
+    await waitFor(() => expect(mockGetLocations).toHaveBeenCalled());
+
+    return { placeholder, ...component };
+  };
+
+  test('should be accessible', async () => {
+    const { container } = await setup();
+
+    const result = await axe(container);
+    expect(result).toHaveNoViolations();
+  });
+
+  test('renders with label', async () => {
+    setup();
+    await waitFor(() => expect(mockGetLocations).toHaveBeenCalled());
+
+    expect(screen.getByText(/Select locations/i)).toBeInTheDocument();
+  });
+
+  test('renders location items when dropdown is opened', async () => {
+    const { user, placeholder } = await setup();
+
+    await user.click(placeholder);
+
+    expect(await screen.findByText(MOCK_LOCATION.name)).toBeInTheDocument();
+    expect(screen.getByText(MOCK_LOCATION.name)).toBeInTheDocument();
+  });
+
+  test('renders location address under the name', async () => {
+    const { user, placeholder } = await setup();
+
+    await user.click(placeholder);
+
+    expect(await screen.findByText(MOCK_LOCATION.address)).toBeInTheDocument();
+    expect(screen.getByText(MOCK_LOCATION_2.address)).toBeInTheDocument();
+  });
+
+  test('displays empty state when no locations found', async () => {
+    mockGetLocations.mockResolvedValue([]);
+    const { user, placeholder } = await setup();
+
+    await user.click(placeholder);
+
+    expect(screen.getByText('No locations found.')).toBeInTheDocument();
+  });
+
+  test('filters locations based on input', async () => {
+    const { user, placeholder } = await setup();
+
+    await user.click(placeholder);
+    await screen.findByText(MOCK_LOCATION.name);
+
+    await user.type(placeholder, 'B');
+
+    await waitFor(() => {
+      expect(screen.getByText(MOCK_LOCATION_2.name)).toBeInTheDocument();
+      expect(screen.queryByText(MOCK_LOCATION.name)).not.toBeInTheDocument();
+    });
+  });
+
+  test('updates form value on selection', async () => {
+    const TestFormWithDisplay = () => {
+      const { control, watch } = useForm<FormValues>({
+        defaultValues: { location_id: null },
+      });
+      const value = watch('location_id');
+      return (
+        <>
+          <LocationSelection control={control} />
+          <div data-testid="form-value">{JSON.stringify(value)}</div>
+        </>
+      );
+    };
+
+    const { user } = renderWithUI(withFreshSWR(<TestFormWithDisplay />));
+
+    await waitFor(() => expect(mockGetLocations).toHaveBeenCalled());
+
+    await user.click(screen.getByPlaceholderText('Type to search'));
+    await user.click(await screen.findByText(MOCK_LOCATION.name));
+
+    expect(screen.getByTestId('form-value')).toHaveTextContent(
+      JSON.stringify(MOCK_LOCATION.location_id),
+    );
+  });
+
+  test('is disabled when isDisabled is true', async () => {
+    const { placeholder } = await setup({ isDisabled: true });
+    expect(placeholder).toBeDisabled();
+  });
+});

--- a/src/components/user/PlayerSelection.test.tsx
+++ b/src/components/user/PlayerSelection.test.tsx
@@ -1,0 +1,149 @@
+import { axe } from 'jest-axe';
+import { SWRConfig } from 'swr';
+
+import { MOCK_PLAYER, MOCK_USER_WITH_PLAYER } from '@/test/mocks/user';
+import { renderWithUI, screen, waitFor } from '@/test/utilities';
+
+import { getActivePlayers } from '@/actions/user';
+import { User } from '@/drizzle/schema/user';
+import { PlayerSelection, SelectedPlayers } from './PlayerSelection';
+
+vi.mock('@/actions/user', () => ({
+  getActivePlayers: vi.fn(),
+}));
+
+const withFreshSWR = (ui: React.ReactElement) => (
+  <SWRConfig value={{ provider: () => new Map() }}>{ui}</SWRConfig>
+);
+
+describe('PlayerSelection', () => {
+  const onSelectionChange = vi.fn();
+  const mockGetActivePlayers = vi.mocked(getActivePlayers);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetActivePlayers.mockResolvedValue([MOCK_USER_WITH_PLAYER]);
+  });
+
+  const setup = async (selection: User[] = []) => {
+    const component = renderWithUI(
+      withFreshSWR(
+        <PlayerSelection
+          selection={selection}
+          onSelectionChange={onSelectionChange}
+        />,
+      ),
+    );
+    const placeholder = screen.getByPlaceholderText('Type to search');
+
+    await waitFor(() => expect(mockGetActivePlayers).toHaveBeenCalled());
+
+    return { placeholder, ...component };
+  };
+
+  test('should be accessible', async () => {
+    const { container } = await setup();
+
+    const result = await axe(container);
+    expect(result).toHaveNoViolations();
+  });
+
+  test('renders with label', async () => {
+    await setup();
+
+    expect(screen.getByText(/Select players/i)).toBeInTheDocument();
+  });
+
+  test('renders player names when dropdown is opened', async () => {
+    const { user, placeholder } = await setup();
+
+    await user.click(placeholder);
+
+    expect(
+      await screen.findByText(MOCK_USER_WITH_PLAYER.name),
+    ).toBeInTheDocument();
+  });
+
+  test('renders jersey number prefix when player has one', async () => {
+    const { user, placeholder } = await setup();
+
+    await user.click(placeholder);
+
+    await screen.findByText(MOCK_USER_WITH_PLAYER.name);
+    expect(
+      screen.getByText(new RegExp(`${MOCK_PLAYER.jersey_number} -`)),
+    ).toBeInTheDocument();
+  });
+
+  test('displays empty state when no players found', async () => {
+    mockGetActivePlayers.mockResolvedValue([]);
+    const { user, placeholder } = await setup();
+
+    await user.click(placeholder);
+
+    expect(screen.getByText('No players found.')).toBeInTheDocument();
+  });
+
+  test('calls onSelectionChange with selected player array', async () => {
+    const { user, placeholder } = await setup();
+
+    await user.click(placeholder);
+    await user.click(await screen.findByText(MOCK_USER_WITH_PLAYER.name));
+
+    expect(onSelectionChange).toHaveBeenCalledWith([MOCK_USER_WITH_PLAYER]);
+  });
+});
+
+describe('SelectedPlayers', () => {
+  const onSelectionChange = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const setup = (selection: Array<User> = [MOCK_USER_WITH_PLAYER]) =>
+    renderWithUI(
+      <SelectedPlayers
+        selection={selection}
+        onSelectionChange={onSelectionChange}
+      />,
+    );
+
+  test('should be accessible', async () => {
+    const { container } = setup();
+
+    const result = await axe(container);
+    expect(result).toHaveNoViolations();
+  });
+
+  test('shows empty state when no players are selected', () => {
+    setup([]);
+
+    expect(screen.getByText('No players selected')).toBeInTheDocument();
+  });
+
+  test('renders selected player names', () => {
+    setup();
+
+    expect(screen.getByText(MOCK_USER_WITH_PLAYER.name)).toBeInTheDocument();
+  });
+
+  test('renders jersey number prefix for players with one', () => {
+    setup();
+
+    expect(
+      screen.getByText(new RegExp(`${MOCK_PLAYER.jersey_number} -`)),
+    ).toBeInTheDocument();
+  });
+
+  test('calls onSelectionChange without removed player on click', async () => {
+    const { user } = setup();
+
+    const playerItem = screen
+      .getByText(MOCK_USER_WITH_PLAYER.name)
+      .closest('li')!;
+    await user.click(playerItem);
+
+    expect(onSelectionChange).toHaveBeenCalledWith([]);
+  });
+});

--- a/src/components/user/RolePositionSelection.test.tsx
+++ b/src/components/user/RolePositionSelection.test.tsx
@@ -1,0 +1,213 @@
+import { axe } from 'jest-axe';
+import { useForm } from 'react-hook-form';
+
+import { renderWithUI, screen, waitFor } from '@/test/utilities';
+
+import { PlayerPosition, UserRole } from '@/utils/enum';
+import { RolePositionSelection, RoleSelection } from './RolePositionSelection';
+
+// ---------------------------------------------------------------------------
+// RoleSelection
+//
+// Note: Always used inside a Field wrapper (e.g.RolePositionSelection),
+// which provides the label context required for full accessibility compliance.
+// ---------------------------------------------------------------------------
+
+describe('RoleSelection', () => {
+  const setup = (
+    overrides: React.ComponentProps<typeof RoleSelection> = {},
+  ) => {
+    const component = renderWithUI(<RoleSelection {...overrides} />);
+    const combobox = screen.getByRole('combobox');
+
+    return { combobox, ...component };
+  };
+
+  test('renders with default placeholder', () => {
+    setup();
+    expect(screen.getByText('Role')).toBeInTheDocument();
+  });
+
+  test('renders with custom placeholder', () => {
+    const customPlaceholder = 'Pick a role';
+    setup({ placeholder: customPlaceholder });
+
+    expect(screen.getByText(customPlaceholder)).toBeInTheDocument();
+  });
+
+  test('renders all role options when opened', async () => {
+    const { user, combobox } = setup();
+
+    await user.click(combobox);
+
+    expect(
+      await screen.findByRole('option', { name: 'Player' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Coach' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Guest' })).toBeInTheDocument();
+  });
+
+  test('is disabled when disabled prop is true', () => {
+    const { combobox } = setup({ disabled: true });
+    expect(combobox).toBeDisabled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RolePositionSelection
+// ---------------------------------------------------------------------------
+
+type FormValues = {
+  role: string;
+  position: string;
+};
+
+function TestRolePositionForm({
+  defaultValues = { role: '', position: '' },
+  disabled = false,
+}: {
+  defaultValues?: Partial<FormValues>;
+  disabled?: boolean;
+}) {
+  const { control, setValue, watch } = useForm<FormValues>({
+    defaultValues: { role: '', position: '', ...defaultValues },
+  });
+  const role = watch('role');
+  const position = watch('position');
+
+  return (
+    <>
+      <RolePositionSelection
+        control={control}
+        roleName="role"
+        positionName="position"
+        disabled={disabled}
+        setValue={setValue}
+      />
+      <div data-testid="role-value">{role}</div>
+      <div data-testid="position-value">{position}</div>
+    </>
+  );
+}
+
+describe('RolePositionSelection', () => {
+  const setup = (
+    props: React.ComponentProps<typeof TestRolePositionForm> = {},
+  ) => {
+    const component = renderWithUI(<TestRolePositionForm {...props} />);
+    const [roleTrigger, positionTrigger] = screen.getAllByRole('combobox');
+
+    return { roleTrigger, positionTrigger, ...component };
+  };
+
+  test('should be accessible', async () => {
+    const { container } = setup();
+
+    const result = await axe(container);
+    expect(result).toHaveNoViolations();
+  });
+
+  test('renders Role and Position field labels', () => {
+    setup();
+
+    expect(screen.getByText('Role', { selector: 'label' })).toBeInTheDocument();
+    expect(
+      screen.getByText('Position', { selector: 'label' }),
+    ).toBeInTheDocument();
+  });
+
+  describe('disable Position field when', () => {
+    test('no role is selected', () => {
+      const { positionTrigger } = setup();
+      expect(positionTrigger).toBeDisabled();
+    });
+
+    test('role GUEST is selected', async () => {
+      const { user, roleTrigger } = setup();
+
+      await user.click(roleTrigger);
+      await user.click(await screen.findByRole('option', { name: 'Guest' }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('position-value')).toHaveTextContent('');
+
+        const [, positionTrigger] = screen.getAllByRole('combobox');
+        expect(positionTrigger).toBeDisabled();
+      });
+    });
+  });
+
+  test('shows player positions when role PLAYER is selected', async () => {
+    const { user, roleTrigger } = setup();
+
+    await user.click(roleTrigger);
+    await user.click(await screen.findByRole('option', { name: 'Player' }));
+
+    await waitFor(() => {
+      const [, positionTrigger] = screen.getAllByRole('combobox');
+      expect(positionTrigger).not.toBeDisabled();
+    });
+
+    const [, positionTrigger] = screen.getAllByRole('combobox');
+    await user.click(positionTrigger);
+
+    expect(
+      await screen.findByRole('option', { name: /^PG/ }),
+    ).toBeInTheDocument();
+  });
+
+  test('shows coach positions when role COACH is selected', async () => {
+    const { user, roleTrigger } = setup();
+
+    await user.click(roleTrigger);
+    await user.click(await screen.findByRole('option', { name: 'Coach' }));
+
+    await waitFor(() => {
+      const [, positionTrigger] = screen.getAllByRole('combobox');
+      expect(positionTrigger).not.toBeDisabled();
+    });
+
+    const [, positionTrigger] = screen.getAllByRole('combobox');
+    await user.click(positionTrigger);
+
+    expect(
+      await screen.findByRole('option', { name: /^Head/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('option', { name: /^Assistant/ }),
+    ).toBeInTheDocument();
+  });
+
+  test('updates form role value on selection', async () => {
+    const { user, roleTrigger } = setup();
+
+    await user.click(roleTrigger);
+    await user.click(await screen.findByRole('option', { name: 'Player' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('role-value')).toHaveTextContent(
+        UserRole.PLAYER,
+      );
+    });
+  });
+
+  test('sets position to UNKNOWN when PLAYER role is selected', async () => {
+    const { user, roleTrigger } = setup();
+
+    await user.click(roleTrigger);
+    await user.click(await screen.findByRole('option', { name: 'Player' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('position-value')).toHaveTextContent(
+        PlayerPosition.UNKNOWN,
+      );
+    });
+  });
+
+  test('both fields are disabled when disabled prop is true', () => {
+    const { roleTrigger, positionTrigger } = setup({ disabled: true });
+
+    expect(roleTrigger).toBeDisabled();
+    expect(positionTrigger).toBeDisabled();
+  });
+});

--- a/src/components/user/StateSelection.test.tsx
+++ b/src/components/user/StateSelection.test.tsx
@@ -1,0 +1,166 @@
+import { axe } from 'jest-axe';
+import { useForm } from 'react-hook-form';
+
+import { renderWithUI, screen, waitFor } from '@/test/utilities';
+
+import { UserState } from '@/utils/enum';
+import { ControlledStateSelection, StateSelection } from './StateSelection';
+
+// ---------------------------------------------------------------------------
+// StateSelection
+// Always used inside a Field wrapper (e.g.ControlledStateSelection),
+// which provides the label context required for full accessibility compliance.
+// ---------------------------------------------------------------------------
+
+describe('StateSelection', () => {
+  const setup = (
+    overrides: React.ComponentProps<typeof StateSelection> = {},
+  ) => {
+    const component = renderWithUI(<StateSelection {...overrides} />);
+    const combobox = screen.getByRole('combobox');
+
+    return { combobox, ...component };
+  };
+
+  test('renders with default placeholder', () => {
+    setup();
+
+    expect(screen.getByText('State')).toBeInTheDocument();
+  });
+
+  test('renders with custom placeholder', () => {
+    const customPlaceholder = 'Pick a state';
+    setup({ placeholder: customPlaceholder });
+
+    expect(screen.getByText(customPlaceholder)).toBeInTheDocument();
+  });
+
+  test('renders all state options when opened', async () => {
+    const { user, combobox } = setup();
+
+    await user.click(combobox);
+
+    expect(
+      await screen.findByRole('option', { name: 'Active' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('option', { name: 'Inactive' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Absent' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Unknown' })).toBeInTheDocument();
+  });
+
+  test('is disabled when disabled prop is true', () => {
+    const { combobox } = setup({ disabled: true });
+
+    expect(combobox).toBeDisabled();
+  });
+
+  test('shows selected state value', async () => {
+    const { user, combobox } = setup();
+
+    await user.click(combobox);
+    await user.click(await screen.findByRole('option', { name: 'Active' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('combobox')).toHaveTextContent('Active');
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ControlledStateSelection
+// ---------------------------------------------------------------------------
+
+type FormValues = { state: string };
+
+function TestControlledStateForm({
+  defaultValues = { state: '' },
+  disabled = false,
+  error,
+}: {
+  defaultValues?: Partial<FormValues>;
+  disabled?: boolean;
+  error?: string;
+}) {
+  const { control, watch } = useForm<FormValues>({
+    defaultValues: { state: '', ...defaultValues },
+  });
+  const state = watch('state');
+
+  return (
+    <>
+      <ControlledStateSelection
+        control={control}
+        name="state"
+        disabled={disabled}
+        error={error}
+      />
+      <div data-testid="state-value">{state}</div>
+    </>
+  );
+}
+
+describe('ControlledStateSelection', () => {
+  const setup = (
+    props: React.ComponentProps<typeof TestControlledStateForm> = {},
+  ) => {
+    const component = renderWithUI(<TestControlledStateForm {...props} />);
+    const combobox = screen.getByRole('combobox');
+
+    return { combobox, ...component };
+  };
+
+  test('should be accessible', async () => {
+    const { container } = setup();
+
+    const result = await axe(container);
+    expect(result).toHaveNoViolations();
+  });
+
+  test('renders State field label', () => {
+    setup();
+
+    expect(
+      screen.getByText('State', { selector: 'label' }),
+    ).toBeInTheDocument();
+  });
+
+  test('renders with pre-selected state from default value', () => {
+    const { combobox } = setup({ defaultValues: { state: UserState.ACTIVE } });
+
+    expect(combobox).toHaveTextContent('Active');
+  });
+
+  test('updates form value when a state is selected', async () => {
+    const { user, combobox } = setup();
+
+    await user.click(combobox);
+    await user.click(await screen.findByRole('option', { name: 'Active' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('state-value')).toHaveTextContent(
+        UserState.ACTIVE,
+      );
+    });
+  });
+
+  test('is disabled when disabled prop is true', () => {
+    const { combobox } = setup({ disabled: true });
+
+    expect(combobox).toBeDisabled();
+  });
+
+  test('displays error message when error prop is provided', () => {
+    const customError = 'State is required';
+    setup({ error: customError });
+
+    expect(screen.getByText(customError)).toBeInTheDocument();
+  });
+
+  test('does not display error when error prop is absent', () => {
+    setup();
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+});

--- a/test/mocks/location.ts
+++ b/test/mocks/location.ts
@@ -7,3 +7,11 @@ export const MOCK_LOCATION: Location = {
   created_at: new Date('2026-01-01'),
   updated_at: new Date('2026-01-01'),
 };
+
+export const MOCK_LOCATION_2: Location = {
+  location_id: 'loc-2',
+  name: 'Bien Hoa Stadium',
+  address: 'Vietnam',
+  created_at: new Date('2026-01-01'),
+  updated_at: new Date('2026-01-01'),
+};

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -9,15 +9,15 @@ export default defineConfig({
     setupFiles: ['./test/setup.ts'], // Reference a setup file
     globals: true, // Utilities functions (like describe, it, etc.)
     css: true, // CSS processing during tests
+    exclude: ['node_modules', 'dist'],
     coverage: {
       exclude: [
+        'coverage/**',
         'test/**',
-        'vite.*.ts',
         '**/*.d.ts',
-        '**/*.test.*',
         '**/*.config.*',
-        '**/snapshot-tests/**',
-        '**/coverage/**',
+        // Chakra UI components (already well-tested by Chakra)
+        '**/components/ui/**',
         // Pure data/type definitions
         '**/utils/constant.ts',
         '**/utils/enum.ts',


### PR DESCRIPTION
#### New ✨

Added new unit test suites for:
  - LocationSelection
  - PlayerSelection/ SelectedPlayers
  - RoleSelection/ RolePositionSelection
  - StateSelection/ ControlledStateSelection.

#### Improvements 🙌

- Expanded location test fixtures with an additional mock location.
- Updated Vitest config `excludes` (test runner + coverage).


_Resolve #161_