### PR TITLE
Session expiry failures for server actions and route navigation

### DIFF
--- a/docs/prd/01-roles-permissions.md
+++ b/docs/prd/01-roles-permissions.md
@@ -6,7 +6,7 @@
 
 Route guard for page navigation only.
 
-→ Block authenticated/ expired page navigation and RBAC before hitting the route handler.
+→ Block unauthenticated/ expired page navigation and RBAC before hitting the route handler.
 
 ### Layer 2: withAuth / withResource
 

--- a/docs/prd/01-roles-permissions.md
+++ b/docs/prd/01-roles-permissions.md
@@ -1,3 +1,27 @@
+# Authentication & Authorization
+
+### Layer 1: Proxy
+
+> proxy.ts
+
+Route guard for page navigation only.
+
+→ Block authenticated/ expired page navigation and RBAC before hitting the route handler.
+
+### Layer 2: withAuth / withResource
+
+> `auth.api.getSession`
+
+- Only layer that cannot be bypassed.
+- Always runs for every server action.
+- Provide `user` context.
+
+### Layer 3: Layout
+
+> `authClient.useSession`
+
+Proactive client-side UX
+
 # Roles, Permissions & Glossary
 
 ## 1. Roles (Definitions)

--- a/src/actions/auth.test.ts
+++ b/src/actions/auth.test.ts
@@ -5,7 +5,7 @@ import auth from '@/lib/auth';
 import { LOGIN_PATH } from '@/routes';
 import { MOCK_PLAYER, MOCK_USER } from '@/test/mocks/user';
 
-import { getServerSession, withAuth } from './auth';
+import { withAuth } from './auth';
 
 type MockHeaders = Awaited<ReturnType<typeof headers>>;
 export type Session = typeof auth.$Infer.Session;
@@ -40,44 +40,6 @@ vi.mock('@/lib/auth', () => ({
 describe('Auth Actions', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-  });
-
-  describe('getServerSession', () => {
-    test('calls auth.api.getSession with headers', async () => {
-      const mockSession = createMockSession();
-      vi.mocked(headers).mockResolvedValue(mockHeaders);
-      vi.mocked(auth.api.getSession).mockResolvedValue(mockSession);
-
-      const result = await getServerSession();
-
-      expect(headers).toHaveBeenCalled();
-      expect(auth.api.getSession).toHaveBeenCalledWith({
-        headers: mockHeaders,
-      });
-      expect(result).toEqual(mockSession);
-    });
-
-    test('returns null when no session exists', async () => {
-      vi.mocked(headers).mockResolvedValue(mockHeaders);
-      vi.mocked(auth.api.getSession).mockResolvedValue(null);
-
-      const result = await getServerSession();
-
-      expect(result).toBeNull();
-    });
-
-    test('caches the result of getSession call', async () => {
-      const mockSession = createMockSession();
-      vi.mocked(headers).mockResolvedValue(mockHeaders);
-      vi.mocked(auth.api.getSession).mockResolvedValue(mockSession);
-
-      // Call twice to verify caching behavior
-      await getServerSession();
-      await getServerSession();
-
-      // Should still be called twice due to test isolation
-      expect(auth.api.getSession).toHaveBeenCalled();
-    });
   });
 
   describe('withAuth', () => {

--- a/src/actions/auth.ts
+++ b/src/actions/auth.ts
@@ -9,7 +9,6 @@
 
 import { headers } from 'next/headers';
 import { forbidden, redirect, RedirectType } from 'next/navigation';
-import { cache } from 'react';
 
 import { User } from '@/drizzle/schema';
 import auth from '@/lib/auth';
@@ -22,20 +21,15 @@ import {
   type Resource,
 } from '@/utils/permissions';
 
-export const getServerSession = cache(
-  async () =>
-    await auth.api.getSession({
-      headers: await headers(),
-    }),
-);
-
 type ServerAction<T extends Array<unknown>, R> = (...args: T) => Promise<R>;
 
 export function withAuth<T extends Array<unknown>, R>(
   serverAction: (user: User, ...args: T) => Promise<R>,
 ): ServerAction<T, R> {
   return async (...args: T): Promise<R> => {
-    const session = await getServerSession();
+    const session = await auth.api.getSession({
+      headers: await headers(),
+    });
 
     if (!session || !session.user) {
       // Currently, it only works for fetching data

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -50,55 +50,52 @@ export default function LoginPage() {
   }
 
   return (
-    <VStack
-      as="form"
-      gap={4}
-      alignItems="stretch"
-      onSubmit={handleSubmit(onSubmit)}
-    >
-      <Heading size={{ base: 'xl', md: '2xl' }} textAlign="center">
-        Sign in to your account
-      </Heading>
+    <form method="POST" onSubmit={handleSubmit(onSubmit)}>
+      <VStack gap={4} alignItems="stretch">
+        <Heading size={{ base: 'xl', md: '2xl' }} textAlign="center">
+          Sign in to your account
+        </Heading>
 
-      <Field
-        required
-        label="Email"
-        disabled={isLoading}
-        invalid={!!errors.email}
-        errorText={errors.email?.message}
-      >
-        <Input autoFocus autoComplete="email" {...register('email')} />
-      </Field>
-      <Field
-        required
-        label="Password"
-        disabled={isLoading}
-        invalid={!!errors.password}
-        errorText={errors.password?.message}
-      >
-        <PasswordInput {...register('password')} />
-      </Field>
+        <Field
+          required
+          label="Email"
+          disabled={isLoading}
+          invalid={!!errors.email}
+          errorText={errors.email?.message}
+        >
+          <Input autoFocus autoComplete="email" {...register('email')} />
+        </Field>
+        <Field
+          required
+          label="Password"
+          disabled={isLoading}
+          invalid={!!errors.password}
+          errorText={errors.password?.message}
+        >
+          <PasswordInput {...register('password')} />
+        </Field>
 
-      <ChakraLink
-        fontSize="sm"
-        fontWeight={500}
-        textDecoration="underline"
-        asChild
-      >
-        <NextLink href="/forgot-password">Forgot your password?</NextLink>
-      </ChakraLink>
+        <ChakraLink
+          fontSize="sm"
+          fontWeight={500}
+          textDecoration="underline"
+          asChild
+        >
+          <NextLink href="/forgot-password">Forgot your password?</NextLink>
+        </ChakraLink>
 
-      {error && <Alert status="error" title={error} />}
+        {error && <Alert status="error" title={error} />}
 
-      <Button
-        type="submit"
-        borderRadius="full"
-        loadingText="Directing..."
-        loading={isLoading}
-        disabled={isLoading}
-      >
-        Sign In
-      </Button>
-    </VStack>
+        <Button
+          type="submit"
+          borderRadius="full"
+          loadingText="Directing..."
+          loading={isLoading}
+          disabled={isLoading}
+        >
+          Sign In
+        </Button>
+      </VStack>
+    </form>
   );
 }

--- a/src/app/(protected)/layout.tsx
+++ b/src/app/(protected)/layout.tsx
@@ -1,15 +1,38 @@
 'use client';
 
-import { PropsWithChildren, Suspense, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { PropsWithChildren, Suspense, useEffect, useState } from 'react';
 
 import { Container, Grid, GridItem, Separator } from '@chakra-ui/react';
+
+import { toaster } from '@/components/ui/toaster';
+
+import authClient from '@/lib/auth-client';
+import { LOGIN_PATH } from '@/routes';
 
 import Header from './_components/AppHeader';
 import Sidebar from './_components/Sidebar';
 
 export default function AuthenticatedLayout({ children }: PropsWithChildren) {
+  const router = useRouter();
   const [isExpanded, setIsExpanded] = useState<boolean>(true);
   const sidebarWidth = isExpanded ? '224px' : '64px';
+
+  const { data: session, isPending } = authClient.useSession();
+
+  // Polling-detected expiry
+  useEffect(() => {
+    if (!isPending && session == null) {
+      router.replace(LOGIN_PATH);
+    }
+  }, [session, isPending, router]);
+
+  // Unmount cleanup (covers server action redirect case)
+  useEffect(() => {
+    return () => {
+      setTimeout(() => toaster.dismiss());
+    };
+  }, []);
 
   return (
     <Grid

--- a/src/app/(system)/forbidden/layout.tsx
+++ b/src/app/(system)/forbidden/layout.tsx
@@ -1,0 +1,5 @@
+import { PropsWithChildren } from 'react';
+
+export default function ForbiddenLayout({ children }: PropsWithChildren) {
+  return <div>{children}</div>;
+}

--- a/src/app/(system)/forbidden/page.tsx
+++ b/src/app/(system)/forbidden/page.tsx
@@ -1,0 +1,5 @@
+import { forbidden } from 'next/navigation';
+
+export default function Forbidden() {
+  forbidden();
+}

--- a/src/hooks/use-permissions.test.ts
+++ b/src/hooks/use-permissions.test.ts
@@ -121,13 +121,13 @@ describe('usePermissions', () => {
       expect(result.current.can('roster', 'create')).toBeTruthy();
     });
 
-    test('GUEST cannot view analytics', () => {
+    test('GUEST cannot view assets', () => {
       (authClient.useSession as Mock).mockReturnValue({
         data: { session: {}, user: { role: UserRole.GUEST } },
         isPending: false,
       });
       const { result } = renderHook(() => usePermissions());
-      expect(result.current.can('analytics', 'view')).toBeFalsy();
+      expect(result.current.can('assets', 'view')).toBeFalsy();
     });
 
     test('PLAYER cannot create roster', () => {
@@ -176,14 +176,14 @@ describe('usePermissions', () => {
       ).toBeTruthy();
     });
 
-    test('GUEST has no analytics permissions', () => {
+    test('GUEST has no assets permissions', () => {
       (authClient.useSession as Mock).mockReturnValue({
         data: { session: {}, user: { role: UserRole.GUEST } },
         isPending: false,
       });
       const { result } = renderHook(() => usePermissions());
       expect(
-        result.current.canAny(['analytics:view', 'analytics:create']),
+        result.current.canAny(['assets:view', 'assets:create']),
       ).toBeFalsy();
     });
   });

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -72,6 +72,7 @@ export default betterAuth({
   advanced: {
     cookiePrefix: COOKIE.prefix,
   },
+  // https://better-auth.com/docs/concepts/session-management
   session: {
     expiresIn: COOKIE.expires,
     cookieCache: {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -10,11 +10,12 @@ import {
 } from '@/routes';
 import { COOKIE } from '@/utils/constant';
 import { UserRole } from '@/utils/enum';
-import { can } from '@/utils/permissions';
+import { can } from './utils/permissions';
 
 /**
  * Resolves the current pathname to a `Resource` using prefix matching.
- * e.g. `/periodic-testing/add-result` → `periodic-testing`
+ *
+ * _e.g.,_ `/periodic-testing/add-result` → `periodic-testing`
  */
 function resolveResource(pathname: string) {
   for (const resource of RESOURCES) {
@@ -26,6 +27,11 @@ function resolveResource(pathname: string) {
 }
 
 export default async function proxy(req: NextRequest) {
+  // Server actions own their own auth via `withAuth`
+  if (req.headers.has('next-action')) {
+    return NextResponse.next();
+  }
+
   const currentPath = req.nextUrl.pathname;
   const isProtectedRoute = !PUBLIC_ROUTES.has(currentPath);
   const isAuthRoute = AUTH_ROUTES.add('/').has(currentPath);
@@ -33,38 +39,36 @@ export default async function proxy(req: NextRequest) {
   const redirectTo = (path: string) =>
     NextResponse.redirect(new URL(path, req.nextUrl));
 
-  // https://www.better-auth.com/docs/integrations/next#middleware
-  const sessionCookie = getSessionCookie(req, {
-    cookiePrefix: COOKIE.prefix,
-  });
+  // Fast check: Cookie read only, no DB (always GET/navigation request)
+  const sessionCookie = getSessionCookie(req, { cookiePrefix: COOKIE.prefix });
   const isLoggedIn = !!sessionCookie;
 
-  // Redirect unauthenticated users from protected routes
+  // Fast redirect: no cookie
   if (!isLoggedIn && isProtectedRoute) {
     return redirectTo(LOGIN_PATH);
   }
 
-  // Redirect authenticated users from auth routes
+  // Fast redirect: Cookie exists and on auth route
   if (isLoggedIn && isAuthRoute) {
     return redirectTo(DEFAULT_LOGIN_REDIRECT);
   }
 
-  // Route-level permission check using cookie cache
   if (isLoggedIn && isProtectedRoute) {
+    // Full validation: Cookie cache read + Protected route
+    const session = await getCookieCache(req, { cookiePrefix: COOKIE.prefix });
+
+    if (!session) {
+      // Session expired - cookie still present but cache is invalid
+      return redirectTo(LOGIN_PATH);
+    }
+
     const resource = resolveResource(currentPath);
 
     if (resource) {
-      const session = await getCookieCache(req, {
-        cookiePrefix: COOKIE.prefix,
-      });
+      const role = session.user.role as UserRole;
 
-      const role = session?.user?.role as UserRole;
-
-      if (!role || !can(role, resource, 'view')) {
-        // FIXME:
-        // Failed to fetch RSC payload for http://localhost:3000/dashboard. Falling back to browser navigation. TypeError: Failed to fetch
-        // => Redirect to a "403 Forbidden" page instead of login redirect (?)
-        // return redirectTo(DEFAULT_LOGIN_REDIRECT);
+      if (!can(role, resource, 'view')) {
+        return redirectTo('/forbidden');
       }
     }
   }

--- a/src/utils/constant.ts
+++ b/src/utils/constant.ts
@@ -29,7 +29,7 @@ export const LOCALE_DATETIME_FORMAT =
 export const COOKIE = {
   prefix: 'sgr',
   expires: 60 * 60, // 1 hour in seconds
-  maxAge: 10 * 60, // 10 minutes in seconds
+  maxAge: 60 * 60,
 };
 
 /**


### PR DESCRIPTION
#### Bug Fixes 🐛

Fixes session-expiry edge cases affecting `Next.js` server actions and `RSC/navigation` requests by aligning `Better Auth` cookie-cache lifetime with the session lifetime, and by tightening middleware behavior around auth + RBAC.

- Align `COOKIE.maxAge` with `COOKIE.expires` to remove the window where the cookie cache expires before the session.
- Update `proxy.ts` to bypass middleware redirects for server actions and to return an explicit response for “no view permission” (redirect to `/forbidden`).
- Add a /forbidden route and a client-side session-expiry redirect in the protected layout for improved UX.

_Resolve #180_
