### PR TITLE
Reuse Card component

### DIFF
--- a/src/app/(protected)/(overview)/dashboard/_components/AbsenceReasonsBreakdown.tsx
+++ b/src/app/(protected)/(overview)/dashboard/_components/AbsenceReasonsBreakdown.tsx
@@ -3,10 +3,10 @@
 import { useMemo } from 'react';
 
 import { Chart, useChart } from '@chakra-ui/charts';
-import { Card } from '@chakra-ui/react';
 import { ChartPie } from 'lucide-react';
 import { Pie, PieChart, PieSectorShapeProps, Sector } from 'recharts';
 
+import { Card } from '@/components/ui/card';
 import { EmptyState } from '@/components/ui/empty-state';
 
 import { AbsenceReason } from '@/types/analytics';
@@ -37,33 +37,28 @@ export default function AbsenceReasonsBreakdown({
   });
 
   return (
-    <Card.Root>
-      <Card.Header>
-        <Card.Title>Most Common Absence Reasons</Card.Title>
-        <Card.Description>
-          Top 5 reasons why players miss training
-        </Card.Description>
-      </Card.Header>
-      <Card.Body>
-        {enrichedReasons.length ? (
-          <Chart.Root maxHeight="xs" chart={chart}>
-            <PieChart responsive>
-              <Pie
-                data={enrichedReasons}
-                labelLine
-                isAnimationActive
-                dataKey={chart.key('count')}
-                label={({ name, value }) => `${name}: ${value}`}
-                shape={(props: PieSectorShapeProps) => (
-                  <Sector {...props} fill={props.payload.color} />
-                )}
-              />
-            </PieChart>
-          </Chart.Root>
-        ) : (
-          <EmptyState icon={<ChartPie />} title="No absence reasons records" />
-        )}
-      </Card.Body>
-    </Card.Root>
+    <Card
+      title="Most Common Absence Reasons"
+      description="Top 5 reasons why players miss training"
+    >
+      {enrichedReasons.length ? (
+        <Chart.Root maxHeight="xs" chart={chart}>
+          <PieChart responsive>
+            <Pie
+              data={enrichedReasons}
+              labelLine
+              isAnimationActive
+              dataKey={chart.key('count')}
+              label={({ name, value }) => `${name}: ${value}`}
+              shape={(props: PieSectorShapeProps) => (
+                <Sector {...props} fill={props.payload.color} />
+              )}
+            />
+          </PieChart>
+        </Chart.Root>
+      ) : (
+        <EmptyState icon={<ChartPie />} title="No absence reasons records" />
+      )}
+    </Card>
   );
 }

--- a/src/app/(protected)/(overview)/dashboard/_components/AttendanceTrend.tsx
+++ b/src/app/(protected)/(overview)/dashboard/_components/AttendanceTrend.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Chart, useChart } from '@chakra-ui/charts';
-import { Box, Card, Span, Text } from '@chakra-ui/react';
+import { Box, Span, Text } from '@chakra-ui/react';
 import { ChartLine } from 'lucide-react';
 import type { TooltipContentProps } from 'recharts';
 import {
@@ -13,6 +13,7 @@ import {
   XAxis,
 } from 'recharts';
 
+import { Card } from '@/components/ui/card';
 import { EmptyState } from '@/components/ui/empty-state';
 
 import { AttendanceHistoryRecord } from '@/types/analytics';
@@ -55,10 +56,10 @@ export default function AttendanceTrend({
     records.length;
 
   return (
-    <Card.Root>
-      <Card.Header>
-        <Card.Title>Attendance Rate Trend</Card.Title>
-        <Card.Description>
+    <Card
+      title="Attendance Rate Trend"
+      description={
+        <>
           Overall team attendance percentage
           {avgRate && (
             <>
@@ -68,44 +69,43 @@ export default function AttendanceTrend({
               </Span>
             </>
           )}
-        </Card.Description>
-      </Card.Header>
-      <Card.Body>
-        {records.length === 0 ? (
-          <EmptyState icon={<ChartLine />} title="No attendance records" />
-        ) : (
-          <Chart.Root chart={chart}>
-            <LineChart data={chart.data} responsive>
-              <CartesianGrid
-                stroke={chart.color('border')}
-                vertical={false}
-                strokeDasharray="2 2"
-              />
-              <XAxis
-                axisLine={false}
-                dataKey={chart.key('short_date')}
-                stroke={chart.color('border')}
-              />
-              <Tooltip content={<CustomTooltip />} />
-              <ReferenceLine
-                y={TARGET_RATE}
-                stroke="orange"
-                strokeDasharray="2 2"
-                label={{
-                  value: `Target (${TARGET_RATE})`,
-                  position: 'top',
-                }}
-              />
-              <Line
-                type="monotone"
-                dataKey={chart.key('present_rate')}
-                stroke={chart.color('green')}
-                strokeWidth={1.5}
-              />
-            </LineChart>
-          </Chart.Root>
-        )}
-      </Card.Body>
-    </Card.Root>
+        </>
+      }
+    >
+      {records.length === 0 ? (
+        <EmptyState icon={<ChartLine />} title="No attendance records" />
+      ) : (
+        <Chart.Root chart={chart}>
+          <LineChart data={chart.data} responsive>
+            <CartesianGrid
+              stroke={chart.color('border')}
+              vertical={false}
+              strokeDasharray="2 2"
+            />
+            <XAxis
+              axisLine={false}
+              dataKey={chart.key('short_date')}
+              stroke={chart.color('border')}
+            />
+            <Tooltip content={<CustomTooltip />} />
+            <ReferenceLine
+              y={TARGET_RATE}
+              stroke="orange"
+              strokeDasharray="2 2"
+              label={{
+                value: `Target (${TARGET_RATE})`,
+                position: 'top',
+              }}
+            />
+            <Line
+              type="monotone"
+              dataKey={chart.key('present_rate')}
+              stroke={chart.color('green')}
+              strokeWidth={1.5}
+            />
+          </LineChart>
+        </Chart.Root>
+      )}
+    </Card>
   );
 }

--- a/src/app/(protected)/(overview)/dashboard/_components/MatchesRate.tsx
+++ b/src/app/(protected)/(overview)/dashboard/_components/MatchesRate.tsx
@@ -1,8 +1,8 @@
 'use client';
 
+import { Card } from '@/components/ui/card';
 import { MatchesRateRecord } from '@/types/analytics';
 import { Chart, useChart } from '@chakra-ui/charts';
-import { Card } from '@chakra-ui/react';
 import { useRouter } from 'next/navigation';
 import {
   Bar,
@@ -29,46 +29,41 @@ export default function MatchesRate({
   });
 
   return (
-    <Card.Root>
-      <Card.Header>
-        <Card.Title>Matches Record</Card.Title>
-        <Card.Description>
-          Performance in league vs friendly matches
-        </Card.Description>
-      </Card.Header>
-      <Card.Body>
-        <Chart.Root chart={chart}>
-          <BarChart data={chart.data} responsive>
-            <CartesianGrid
-              stroke={chart.color('border.muted')}
-              vertical={false}
-              strokeDasharray="2 2"
-            />
-            <XAxis
-              axisLine={false}
-              tickLine={false}
-              dataKey={chart.key('outcome')}
-            />
-            <Tooltip
-              content={<Chart.Tooltip />}
-              cursor={{ fill: chart.color('bg.muted') }}
-            />
-            <Legend content={<Chart.Legend />} />
-            {chart.series.map((item) => (
-              <Bar
-                key={item.name}
-                stackId={item.stackId}
-                dataKey={chart.key(item.name)}
-                fill={chart.color(item.color)}
-                stroke={chart.color(item.color)}
-                onClick={() => router.push(`/matches?match_type=${item.name}`)}
-              >
-                <LabelList position="top" dataKey={chart.key(item.name)} />
-              </Bar>
-            ))}
-          </BarChart>
-        </Chart.Root>
-      </Card.Body>
-    </Card.Root>
+    <Card
+      title="Matches Record"
+      description="Performance in league vs friendly matches"
+    >
+      <Chart.Root chart={chart}>
+        <BarChart data={chart.data} responsive>
+          <CartesianGrid
+            stroke={chart.color('border.muted')}
+            vertical={false}
+            strokeDasharray="2 2"
+          />
+          <XAxis
+            axisLine={false}
+            tickLine={false}
+            dataKey={chart.key('outcome')}
+          />
+          <Tooltip
+            content={<Chart.Tooltip />}
+            cursor={{ fill: chart.color('bg.muted') }}
+          />
+          <Legend content={<Chart.Legend />} />
+          {chart.series.map((item) => (
+            <Bar
+              key={item.name}
+              stackId={item.stackId}
+              dataKey={chart.key(item.name)}
+              fill={chart.color(item.color)}
+              stroke={chart.color(item.color)}
+              onClick={() => router.push(`/matches?match_type=${item.name}`)}
+            >
+              <LabelList position="top" dataKey={chart.key(item.name)} />
+            </Bar>
+          ))}
+        </BarChart>
+      </Chart.Root>
+    </Card>
   );
 }

--- a/src/app/(protected)/(overview)/dashboard/_components/OverviewStats.tsx
+++ b/src/app/(protected)/(overview)/dashboard/_components/OverviewStats.tsx
@@ -1,48 +1,42 @@
 import { getOverviewStats } from '@/actions/analytics';
-import { Card, SimpleGrid, Span, Stat } from '@chakra-ui/react';
+import { SimpleGrid, Span, Stat } from '@chakra-ui/react';
+
+import { Card } from '@/components/ui/card';
 
 export default async function OverviewStats() {
   const stats = await getOverviewStats();
 
   return (
-    <Card.Root>
-      <Card.Header>
-        <Card.Title>Overview</Card.Title>
-        <Card.Description>
-          Key performance indicators at a glance
-        </Card.Description>
-      </Card.Header>
-      <Card.Body>
-        <SimpleGrid columns={3} gap={6}>
-          <Stat.Root borderWidth={1} padding={4} rounded="md">
-            <Stat.Label>Active Players</Stat.Label>
-            <Stat.ValueText alignItems="baseline" color="tomato">
-              {stats.active_players}
-            </Stat.ValueText>
-          </Stat.Root>
-          <Stat.Root
-            borderWidth={1}
-            padding={4}
-            rounded="md"
-            hidden={stats.next_game == null}
-          >
-            <Stat.Label>Next Game</Stat.Label>
-            <Stat.ValueText alignItems="baseline">
-              {stats.next_game}
-              <Stat.ValueUnit>days remaining</Stat.ValueUnit>
-            </Stat.ValueText>
-          </Stat.Root>
-          <Stat.Root borderWidth={1} padding={4} rounded="md">
-            <Stat.Label>Win Rate</Stat.Label>
-            <Stat.ValueText alignItems="baseline">
-              <Span color={stats.win_rate > 50 ? 'green' : 'tomato'}>
-                {stats.win_rate}
-              </Span>
-              <Stat.ValueUnit>%</Stat.ValueUnit>
-            </Stat.ValueText>
-          </Stat.Root>
-        </SimpleGrid>
-      </Card.Body>
-    </Card.Root>
+    <Card title="Overview" description="Key performance indicators at a glance">
+      <SimpleGrid columns={3} gap={6}>
+        <Stat.Root borderWidth={1} padding={4} rounded="md">
+          <Stat.Label>Active Players</Stat.Label>
+          <Stat.ValueText alignItems="baseline" color="tomato">
+            {stats.active_players}
+          </Stat.ValueText>
+        </Stat.Root>
+        <Stat.Root
+          borderWidth={1}
+          padding={4}
+          rounded="md"
+          hidden={stats.next_game == null}
+        >
+          <Stat.Label>Next Game</Stat.Label>
+          <Stat.ValueText alignItems="baseline">
+            {stats.next_game}
+            <Stat.ValueUnit>days remaining</Stat.ValueUnit>
+          </Stat.ValueText>
+        </Stat.Root>
+        <Stat.Root borderWidth={1} padding={4} rounded="md">
+          <Stat.Label>Win Rate</Stat.Label>
+          <Stat.ValueText alignItems="baseline">
+            <Span color={stats.win_rate > 50 ? 'green' : 'tomato'}>
+              {stats.win_rate}
+            </Span>
+            <Stat.ValueUnit>%</Stat.ValueUnit>
+          </Stat.ValueText>
+        </Stat.Root>
+      </SimpleGrid>
+    </Card>
   );
 }

--- a/src/app/(protected)/(overview)/dashboard/_components/PlayerAttendanceRanking.tsx
+++ b/src/app/(protected)/(overview)/dashboard/_components/PlayerAttendanceRanking.tsx
@@ -1,6 +1,7 @@
-import { Card, HStack, Span, Text, VStack } from '@chakra-ui/react';
+import { HStack, Span, Text, VStack } from '@chakra-ui/react';
 import { BetweenVerticalEnd, TrendingDown, TrendingUp } from 'lucide-react';
 
+import { Card } from '@/components/ui/card';
 import { EmptyState } from '@/components/ui/empty-state';
 
 import { PlayerSessionSummary, PlayerStats } from '@/types/analytics';
@@ -44,42 +45,33 @@ export default function PlayerAttendanceRanking({
   ];
 
   return (
-    <Card.Root height="full">
-      <Card.Header>
-        <Card.Title>Player Attendance Rankings</Card.Title>
-        <Card.Description>
-          Stars of attendance and teammates who need a boost
-        </Card.Description>
-      </Card.Header>
-      <Card.Body>
-        {!records.top_performers.length && !records.need_attention.length ? (
-          <EmptyState
-            icon={<BetweenVerticalEnd />}
-            title="No player attendance records"
-          />
-        ) : (
-          section.map(
-            ({ title, color, icon: Icon, data }, index) =>
-              data.length > 0 && (
-                <VStack
-                  key={index}
-                  alignItems="stretch"
-                  gap={2}
-                  marginBottom={4}
-                >
-                  <HStack gap={2} color={color}>
-                    <Icon size={16} />
-                    <Span fontSize="sm" fontWeight="medium">
-                      {title}
-                    </Span>
-                  </HStack>
+    <Card
+      height="full"
+      title="Player Attendance Rankings"
+      description="Stars of attendance and teammates who need a boost"
+    >
+      {!records.top_performers.length && !records.need_attention.length ? (
+        <EmptyState
+          icon={<BetweenVerticalEnd />}
+          title="No player attendance records"
+        />
+      ) : (
+        section.map(
+          ({ title, color, icon: Icon, data }, index) =>
+            data.length > 0 && (
+              <VStack key={index} alignItems="stretch" gap={2} marginBottom={4}>
+                <HStack gap={2} color={color}>
+                  <Icon size={16} />
+                  <Span fontSize="sm" fontWeight="medium">
+                    {title}
+                  </Span>
+                </HStack>
 
-                  {data.map(PlayerRank)}
-                </VStack>
-              ),
-          )
-        )}
-      </Card.Body>
-    </Card.Root>
+                {data.map(PlayerRank)}
+              </VStack>
+            ),
+        )
+      )}
+    </Card>
   );
 }

--- a/src/app/(protected)/(overview)/dashboard/_components/UpcomingMatches.tsx
+++ b/src/app/(protected)/(overview)/dashboard/_components/UpcomingMatches.tsx
@@ -1,8 +1,9 @@
-import { Badge, Card, HStack, Span, VStack } from '@chakra-ui/react';
+import { Badge, HStack, Span, VStack } from '@chakra-ui/react';
 import { isToday as isTodayParser } from 'date-fns';
 import { CircleOff, MapPin } from 'lucide-react';
 
 import { LocationLink } from '@/components/common/LocationSelection';
+import { Card } from '@/components/ui/card';
 import { EmptyState } from '@/components/ui/empty-state';
 
 import { getUpcomingMatches } from '@/actions/analytics';
@@ -12,72 +13,66 @@ export default async function UpcomingMatches() {
   const matches = await getUpcomingMatches();
 
   return (
-    <Card.Root>
-      <Card.Header>
-        <Card.Title>Upcoming Matches</Card.Title>
-        <Card.Description>Next 3 scheduled games</Card.Description>
-      </Card.Header>
-      <Card.Body>
-        <VStack alignItems="stretch" gap={4}>
-          {matches.length > 0 ? (
-            matches.map(({ match_id, date, time, location, league }) => {
-              const isToday = isTodayParser(date);
-              const isLeague = !!league?.league_id;
+    <Card title="Upcoming Matches" description="Next 3 scheduled games">
+      <VStack alignItems="stretch" gap={4}>
+        {matches.length > 0 ? (
+          matches.map(({ match_id, date, time, location, league }) => {
+            const isToday = isTodayParser(date);
+            const isLeague = !!league?.league_id;
 
-              return (
-                <HStack
-                  key={match_id}
-                  gap={4}
-                  padding={4}
-                  borderRadius="sm"
-                  borderLeft="4px solid"
-                  backgroundColor={isToday ? 'gray.100' : 'gray.50'}
-                  borderColor={isToday ? 'blue.500' : 'gray.300'}
-                  _hover={{
-                    backgroundColor: isToday ? 'blue.50' : 'gray.100',
-                    transition: 'background-color 0.2s',
-                  }}
-                >
-                  <VStack align="start" flex={1} gap={1}>
-                    <HStack gap={2} width="full">
-                      <Span fontSize="sm">{formatDay(date)}</Span>
-                      <Span color="gray.400">&bull;</Span>
-                      <Span fontSize="sm">{formatDate(date)}</Span>
-                      <Span color="gray.400">&bull;</Span>
-                      <Span fontSize="sm">{time}</Span>
-                      {isToday && (
-                        <Badge
-                          marginLeft="auto"
-                          size="sm"
-                          borderRadius="full"
-                          variant="surface"
-                          colorPalette="red"
-                        >
-                          TODAY
-                        </Badge>
-                      )}
-                    </HStack>
+            return (
+              <HStack
+                key={match_id}
+                gap={4}
+                padding={4}
+                borderRadius="sm"
+                borderLeft="4px solid"
+                backgroundColor={isToday ? 'gray.100' : 'gray.50'}
+                borderColor={isToday ? 'blue.500' : 'gray.300'}
+                _hover={{
+                  backgroundColor: isToday ? 'blue.50' : 'gray.100',
+                  transition: 'background-color 0.2s',
+                }}
+              >
+                <VStack align="start" flex={1} gap={1}>
+                  <HStack gap={2} width="full">
+                    <Span fontSize="sm">{formatDay(date)}</Span>
+                    <Span color="gray.400">&bull;</Span>
+                    <Span fontSize="sm">{formatDate(date)}</Span>
+                    <Span color="gray.400">&bull;</Span>
+                    <Span fontSize="sm">{time}</Span>
+                    {isToday && (
+                      <Badge
+                        marginLeft="auto"
+                        size="sm"
+                        borderRadius="full"
+                        variant="surface"
+                        colorPalette="red"
+                      >
+                        TODAY
+                      </Badge>
+                    )}
+                  </HStack>
 
-                    <HStack fontSize="sm" color="gray.600" width="full">
-                      <MapPin size={12} />
-                      <LocationLink name={location?.name} />
-                      <Span fontSize="sm" marginLeft="auto">
-                        {isLeague ? league.name : 'Friendly'}
-                      </Span>
-                    </HStack>
-                  </VStack>
-                </HStack>
-              );
-            })
-          ) : (
-            <EmptyState
-              icon={<CircleOff />}
-              title="Nothing here"
-              description="Focus on training and get ready for the next game!"
-            />
-          )}
-        </VStack>
-      </Card.Body>
-    </Card.Root>
+                  <HStack fontSize="sm" color="gray.600" width="full">
+                    <MapPin size={12} />
+                    <LocationLink name={location?.name} />
+                    <Span fontSize="sm" marginLeft="auto">
+                      {isLeague ? league.name : 'Friendly'}
+                    </Span>
+                  </HStack>
+                </VStack>
+              </HStack>
+            );
+          })
+        ) : (
+          <EmptyState
+            icon={<CircleOff />}
+            title="Nothing here"
+            description="Focus on training and get ready for the next game!"
+          />
+        )}
+      </VStack>
+    </Card>
   );
 }

--- a/src/app/(protected)/(overview)/dashboard/_components/UpcomingSessions.tsx
+++ b/src/app/(protected)/(overview)/dashboard/_components/UpcomingSessions.tsx
@@ -1,8 +1,9 @@
-import { Badge, Card, Flex, HStack, Span, VStack } from '@chakra-ui/react';
+import { Badge, Flex, HStack, Span, VStack } from '@chakra-ui/react';
 import { isToday as isTodayParser } from 'date-fns';
 import { CircleOff, MapPin } from 'lucide-react';
 
 import { LocationLink } from '@/components/common/LocationSelection';
+import { Card } from '@/components/ui/card';
 import { EmptyState } from '@/components/ui/empty-state';
 
 import { getUpcomingSessions } from '@/actions/analytics';
@@ -12,77 +13,71 @@ export default async function UpcomingSessions() {
   const sessions = await getUpcomingSessions();
 
   return (
-    <Card.Root>
-      <Card.Header>
-        <Card.Title>Upcoming Sessions</Card.Title>
-        <Card.Description>Next 3 training sessions</Card.Description>
-      </Card.Header>
-      <Card.Body>
-        <VStack alignItems="stretch" gap={4}>
-          {sessions.length > 0 ? (
-            sessions.map(
-              ({ session_id, date, start_time, end_time, location }) => {
-                const isToday = isTodayParser(date);
+    <Card title="Upcoming Sessions" description="Next 3 training sessions">
+      <VStack alignItems="stretch" gap={4}>
+        {sessions.length > 0 ? (
+          sessions.map(
+            ({ session_id, date, start_time, end_time, location }) => {
+              const isToday = isTodayParser(date);
 
-                return (
-                  <Flex
-                    key={session_id}
-                    gap={4}
-                    padding={4}
-                    borderRadius="sm"
-                    borderLeft="4px solid"
-                    backgroundColor={isToday ? 'blue.50' : 'gray.50'}
-                    borderColor={isToday ? 'blue.500' : 'gray.300'}
-                    _hover={{
-                      backgroundColor: isToday ? 'blue.100' : 'gray.100',
-                      transition: 'background-color 0.2s',
-                    }}
-                  >
-                    <VStack alignItems="start" flex={1} gap={1}>
-                      <HStack gap={2} width="full">
-                        <Span fontSize="sm">{formatDay(date)}</Span>
-                        <Span color="gray.400">&bull;</Span>
-                        <Span fontSize="sm">{formatDate(date)}</Span>
-                        <Span color="gray.400">&bull;</Span>
-                        <Span fontSize="sm">
-                          <HStack gap={1}>
-                            <Span>{start_time}</Span>
-                            <Span color="gray.400">&rarr;</Span>
-                            <Span>{end_time}</Span>
-                          </HStack>
-                        </Span>
-                        <HStack marginLeft="auto">
-                          {isToday && (
-                            <Badge
-                              size="sm"
-                              borderRadius="full"
-                              variant="surface"
-                              colorPalette="blue"
-                            >
-                              Today
-                            </Badge>
-                          )}
+              return (
+                <Flex
+                  key={session_id}
+                  gap={4}
+                  padding={4}
+                  borderRadius="sm"
+                  borderLeft="4px solid"
+                  backgroundColor={isToday ? 'blue.50' : 'gray.50'}
+                  borderColor={isToday ? 'blue.500' : 'gray.300'}
+                  _hover={{
+                    backgroundColor: isToday ? 'blue.100' : 'gray.100',
+                    transition: 'background-color 0.2s',
+                  }}
+                >
+                  <VStack alignItems="start" flex={1} gap={1}>
+                    <HStack gap={2} width="full">
+                      <Span fontSize="sm">{formatDay(date)}</Span>
+                      <Span color="gray.400">&bull;</Span>
+                      <Span fontSize="sm">{formatDate(date)}</Span>
+                      <Span color="gray.400">&bull;</Span>
+                      <Span fontSize="sm">
+                        <HStack gap={1}>
+                          <Span>{start_time}</Span>
+                          <Span color="gray.400">&rarr;</Span>
+                          <Span>{end_time}</Span>
                         </HStack>
+                      </Span>
+                      <HStack marginLeft="auto">
+                        {isToday && (
+                          <Badge
+                            size="sm"
+                            borderRadius="full"
+                            variant="surface"
+                            colorPalette="blue"
+                          >
+                            Today
+                          </Badge>
+                        )}
                       </HStack>
+                    </HStack>
 
-                      <HStack fontSize="sm" color="gray.600">
-                        <MapPin size={14} />
-                        <LocationLink name={location?.name} />
-                      </HStack>
-                    </VStack>
-                  </Flex>
-                );
-              },
-            )
-          ) : (
-            <EmptyState
-              icon={<CircleOff />}
-              title="Nothing here"
-              description="Upcoming training sessions will be coming soon."
-            />
-          )}
-        </VStack>
-      </Card.Body>
-    </Card.Root>
+                    <HStack fontSize="sm" color="gray.600">
+                      <MapPin size={14} />
+                      <LocationLink name={location?.name} />
+                    </HStack>
+                  </VStack>
+                </Flex>
+              );
+            },
+          )
+        ) : (
+          <EmptyState
+            icon={<CircleOff />}
+            title="Nothing here"
+            description="Upcoming training sessions will be coming soon."
+          />
+        )}
+      </VStack>
+    </Card>
   );
 }

--- a/src/app/(protected)/(performance)/periodic-testing/add-result/_components/AddTestResultPageClient.tsx
+++ b/src/app/(protected)/(performance)/periodic-testing/add-result/_components/AddTestResultPageClient.tsx
@@ -3,11 +3,12 @@
 import { useRouter } from 'next/navigation';
 import { useState, useTransition } from 'react';
 
-import { Button, Card, Highlight, HStack, SimpleGrid } from '@chakra-ui/react';
+import { Button, Highlight, SimpleGrid } from '@chakra-ui/react';
 import { format } from 'date-fns';
 import { Save } from 'lucide-react';
 
 import StepIndicator from '@/components/StepIndicator';
+import { Card } from '@/components/ui/card';
 import { toaster } from '@/components/ui/toaster';
 
 import { createTestResult } from '@/actions/test-result';
@@ -58,57 +59,55 @@ export default function AddTestResultPageClient() {
       gap={6}
       templateColumns={{ lg: '3fr 7fr' }}
     >
-      <Card.Root>
-        <Card.Header>
-          <Card.Title>
+      <Card
+        title={
+          <>
             <StepIndicator step={1} />
             Test Configuration
-          </Card.Title>
-          <Card.Description>
-            <Highlight
-              query="active"
-              styles={{ px: '0.5', backgroundColor: 'green.100' }}
-            >
-              Only active players can be joined to the test.
-            </Highlight>
-          </Card.Description>
-        </Card.Header>
-        <Card.Body>
-          <TestResultConfiguration
-            selection={selection}
-            setSelection={setSelection}
-          />
-        </Card.Body>
-      </Card.Root>
-      <Card.Root>
-        <Card.Header>
-          <HStack justifyContent="space-between">
-            <Card.Title>
-              <StepIndicator step={2} />
-              Test Result
-            </Card.Title>
-            <Button
-              disabled={
-                !selection.players.length ||
-                !selection.types.length ||
-                !tableData.length ||
-                isPending
-              }
-              onClick={() => onSave(tableData)}
-            >
-              <Save />
-              Save
-            </Button>
-          </HStack>
-        </Card.Header>
-        <Card.Body>
-          <TestResultTable
-            configuration={selection}
-            setSelection={setSelection}
-            onChange={setTableData}
-          />
-        </Card.Body>
-      </Card.Root>
+          </>
+        }
+        description={
+          <Highlight
+            query="active"
+            styles={{ px: '0.5', backgroundColor: 'green.100' }}
+          >
+            Only active players can be joined to the test.
+          </Highlight>
+        }
+      >
+        <TestResultConfiguration
+          selection={selection}
+          setSelection={setSelection}
+        />
+      </Card>
+      <Card
+        title={
+          <>
+            <StepIndicator step={2} />
+            Test Result
+          </>
+        }
+        action={
+          <Button
+            disabled={
+              !selection.players.length ||
+              !selection.types.length ||
+              !tableData.length ||
+              isPending
+            }
+            onClick={() => onSave(tableData)}
+          >
+            <Save />
+            Save
+          </Button>
+        }
+      >
+        <TestResultTable
+          configuration={selection}
+          setSelection={setSelection}
+          onChange={setTableData}
+        />
+      </Card>
     </SimpleGrid>
   );
 }

--- a/src/app/(protected)/(team-management)/registration/_components/PreviewPanel.tsx
+++ b/src/app/(protected)/(team-management)/registration/_components/PreviewPanel.tsx
@@ -87,9 +87,8 @@ export default function PreviewPanel({
 
   return (
     <Card
-      size="sm"
       title={
-        <HStack gap={2}>
+        <HStack>
           <Eye size={16} />
           Preview
         </HStack>
@@ -123,7 +122,7 @@ export default function PreviewPanel({
         </HStack>
       }
       footer={
-        <Text fontSize="sm" color="fg.muted" marginInline="auto">
+        <Text fontSize="xs" color="fg.muted" marginInline="auto">
           {template
             ? `Using uploaded form: ${template.name}`
             : 'No PDF uploaded - showing the registration as a table.'}

--- a/src/app/(protected)/(team-management)/registration/_components/PreviewPanel.tsx
+++ b/src/app/(protected)/(team-management)/registration/_components/PreviewPanel.tsx
@@ -2,15 +2,7 @@
 
 import { useEffect, useState } from 'react';
 
-import {
-  Box,
-  Button,
-  Card,
-  HStack,
-  Spinner,
-  Table,
-  Text,
-} from '@chakra-ui/react';
+import { Box, Button, HStack, Spinner, Table, Text } from '@chakra-ui/react';
 import {
   Eye,
   FileDown,
@@ -19,6 +11,7 @@ import {
   Table as TableIcon,
 } from 'lucide-react';
 
+import { Card } from '@/components/ui/card';
 import { EmptyState } from '@/components/ui/empty-state';
 import { toaster } from '@/components/ui/toaster';
 
@@ -93,61 +86,63 @@ export default function PreviewPanel({
   };
 
   return (
-    <Card.Root size="sm">
-      <Card.Header>
-        <HStack alignItems="start" justifyContent="space-between">
-          <HStack gap={2}>
-            <Eye size={16} />
-            <Card.Title>Preview</Card.Title>
-          </HStack>
-          <HStack>
-            <Button
-              size={{ base: 'xs', md: 'sm' }}
-              variant="outline"
-              disabled={!ready}
-              onClick={handleCsv}
-            >
-              <FileText /> CSV
-            </Button>
-            <Button
-              size={{ base: 'xs', md: 'sm' }}
-              variant="outline"
-              loading={busy}
-              disabled={!ready}
-              onClick={handlePdf}
-            >
-              <FileDown /> PDF
-            </Button>
-            <Button
-              size={{ base: 'xs', md: 'sm' }}
-              disabled={!ready}
-              onClick={onSave}
-            >
-              <Save /> Save
-            </Button>
-          </HStack>
+    <Card
+      size="sm"
+      title={
+        <HStack gap={2}>
+          <Eye size={16} />
+          Preview
         </HStack>
-      </Card.Header>
-      <Card.Body>
-        {!ready ? (
-          <EmptyState
-            size="sm"
-            icon={<TableIcon />}
-            title="Nothing to preview yet"
-            description="Select at least one player and a league to see the preview."
-          />
-        ) : template ? (
-          <PdfPreview players={players} league={league} template={template} />
-        ) : (
-          <TablePreview players={players} />
-        )}
-      </Card.Body>
-      <Card.Footer fontSize="sm" color="fg.muted" alignSelf="center">
-        {template
-          ? `Using uploaded form: ${template.name}`
-          : 'No PDF uploaded - showing the registration as a table.'}
-      </Card.Footer>
-    </Card.Root>
+      }
+      action={
+        <HStack>
+          <Button
+            size={{ base: 'xs', md: 'sm' }}
+            variant="outline"
+            disabled={!ready}
+            onClick={handleCsv}
+          >
+            <FileText /> CSV
+          </Button>
+          <Button
+            size={{ base: 'xs', md: 'sm' }}
+            variant="outline"
+            loading={busy}
+            disabled={!ready}
+            onClick={handlePdf}
+          >
+            <FileDown /> PDF
+          </Button>
+          <Button
+            size={{ base: 'xs', md: 'sm' }}
+            disabled={!ready}
+            onClick={onSave}
+          >
+            <Save /> Save
+          </Button>
+        </HStack>
+      }
+      footer={
+        <Text fontSize="sm" color="fg.muted" marginInline="auto">
+          {template
+            ? `Using uploaded form: ${template.name}`
+            : 'No PDF uploaded - showing the registration as a table.'}
+        </Text>
+      }
+    >
+      {!ready ? (
+        <EmptyState
+          size="sm"
+          icon={<TableIcon />}
+          title="Nothing to preview yet"
+          description="Select at least one player and a league to see the preview."
+        />
+      ) : template ? (
+        <PdfPreview players={players} league={league} template={template} />
+      ) : (
+        <TablePreview players={players} />
+      )}
+    </Card>
   );
 }
 

--- a/src/app/(protected)/(team-management)/registration/_components/SavedRegistrations.tsx
+++ b/src/app/(protected)/(team-management)/registration/_components/SavedRegistrations.tsx
@@ -86,7 +86,6 @@ export default function SavedRegistrations({
 
   return (
     <Card
-      size="sm"
       title="Saved registrations"
       description="Recent league registrations you have saved."
     >

--- a/src/app/(protected)/(team-management)/registration/_components/SavedRegistrations.tsx
+++ b/src/app/(protected)/(team-management)/registration/_components/SavedRegistrations.tsx
@@ -2,12 +2,13 @@
 
 import { useCallback, useState } from 'react';
 
-import { Card, HStack, IconButton, Table } from '@chakra-ui/react';
+import { HStack, IconButton, Table } from '@chakra-ui/react';
 import { Download, Trash2 } from 'lucide-react';
 
 import HighlightText from '@/components/HighlightText';
 import Pagination from '@/components/Pagination';
 import SearchInput from '@/components/SearchInput';
+import { Card } from '@/components/ui/card';
 import { EmptyState } from '@/components/ui/empty-state';
 import { toaster } from '@/components/ui/toaster';
 
@@ -84,83 +85,79 @@ export default function SavedRegistrations({
   };
 
   return (
-    <Card.Root size="sm">
-      <Card.Header>
-        <Card.Title>Saved registrations</Card.Title>
-        <Card.Description>
-          Recent league registrations you have saved.
-        </Card.Description>
-      </Card.Header>
-      <Card.Body>
-        <SearchInput placeholder="Filter by name..." />
+    <Card
+      size="sm"
+      title="Saved registrations"
+      description="Recent league registrations you have saved."
+    >
+      <SearchInput placeholder="Filter by name..." />
 
-        <Table.ScrollArea marginBlock={4}>
-          <Table.Root size="sm">
-            <Table.Header>
-              <Table.Row>
-                {HEADERS.map((header) => (
-                  <Table.ColumnHeader key={header} paddingBlock={3}>
-                    {header}
-                  </Table.ColumnHeader>
-                ))}
-              </Table.Row>
-            </Table.Header>
-            <Table.Body>
-              {currentData.length > 0 ? (
-                currentData.map((item) => (
-                  <Table.Row key={item.id}>
-                    <Table.Cell fontWeight="medium">
-                      <HighlightText query={q}>{item.leagueName}</HighlightText>
-                    </Table.Cell>
-                    <Table.Cell>{item.playerCount}</Table.Cell>
-                    <Table.Cell whiteSpace="nowrap">
-                      {formatDatetime(item.savedAt)}
-                    </Table.Cell>
-                    <Table.Cell>
-                      <HStack gap={1}>
-                        <IconButton
-                          size="xs"
-                          variant="ghost"
-                          hidden={!item.pdfBase64}
-                          disabled={isDownloading}
-                          onClick={() => handleDownload(item)}
-                        >
-                          <Download />
-                        </IconButton>
-                        <IconButton
-                          size="xs"
-                          variant="ghost"
-                          colorPalette="red"
-                          disabled={isDownloading}
-                          onClick={() => handleRemove(item)}
-                        >
-                          <Trash2 />
-                        </IconButton>
-                      </HStack>
-                    </Table.Cell>
-                  </Table.Row>
-                ))
-              ) : (
-                <Table.Row>
-                  <Table.Cell colSpan={HEADERS.length}>
-                    <EmptyState
-                      size="sm"
-                      title="No saved registrations yet"
-                      description="Click Save in the preview to keep a registration here."
-                    />
+      <Table.ScrollArea marginBlock={4}>
+        <Table.Root size="sm">
+          <Table.Header>
+            <Table.Row>
+              {HEADERS.map((header) => (
+                <Table.ColumnHeader key={header} paddingBlock={3}>
+                  {header}
+                </Table.ColumnHeader>
+              ))}
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            {currentData.length > 0 ? (
+              currentData.map((item) => (
+                <Table.Row key={item.id}>
+                  <Table.Cell fontWeight="medium">
+                    <HighlightText query={q}>{item.leagueName}</HighlightText>
+                  </Table.Cell>
+                  <Table.Cell>{item.playerCount}</Table.Cell>
+                  <Table.Cell whiteSpace="nowrap">
+                    {formatDatetime(item.savedAt)}
+                  </Table.Cell>
+                  <Table.Cell>
+                    <HStack gap={1}>
+                      <IconButton
+                        size="xs"
+                        variant="ghost"
+                        hidden={!item.pdfBase64}
+                        disabled={isDownloading}
+                        onClick={() => handleDownload(item)}
+                      >
+                        <Download />
+                      </IconButton>
+                      <IconButton
+                        size="xs"
+                        variant="ghost"
+                        colorPalette="red"
+                        disabled={isDownloading}
+                        onClick={() => handleRemove(item)}
+                      >
+                        <Trash2 />
+                      </IconButton>
+                    </HStack>
                   </Table.Cell>
                 </Table.Row>
-              )}
-            </Table.Body>
-          </Table.Root>
-        </Table.ScrollArea>
+              ))
+            ) : (
+              <Table.Row>
+                <Table.Cell colSpan={HEADERS.length}>
+                  <EmptyState
+                    size="sm"
+                    title="No saved registrations yet"
+                    description="Click Save in the preview to keep a registration here."
+                  />
+                </Table.Cell>
+              </Table.Row>
+            )}
+          </Table.Body>
+        </Table.Root>
+      </Table.ScrollArea>
 
-        <Pagination
-          count={totalCount}
-          page={page}
-          onPageChange={setSearchParams}
-        />
-      </Card.Body>
-    </Card.Root>
+      <Pagination
+        count={totalCount}
+        page={page}
+        onPageChange={setSearchParams}
+      />
+    </Card>
   );
 }

--- a/src/app/(protected)/(team-management)/registration/_components/main.tsx
+++ b/src/app/(protected)/(team-management)/registration/_components/main.tsx
@@ -129,7 +129,6 @@ export default function RegistrationPageClient() {
       <SimpleGrid columns={{ base: 1, lg: 12 }} gap={6} alignItems="start">
         <GridItem colSpan={{ base: 1, lg: 5 }}>
           <Card
-            size="sm"
             title={
               <HStack>
                 <UsersRound size={16} />
@@ -183,7 +182,6 @@ export default function RegistrationPageClient() {
           </Card>
 
           <Card
-            size="sm"
             marginBlock={6}
             title={
               <HStack>
@@ -207,7 +205,6 @@ export default function RegistrationPageClient() {
           </Card>
 
           <Card
-            size="sm"
             title={
               <HStack>
                 <Upload size={16} />

--- a/src/app/(protected)/(team-management)/registration/_components/main.tsx
+++ b/src/app/(protected)/(team-management)/registration/_components/main.tsx
@@ -6,7 +6,6 @@ import useSWR from 'swr';
 import {
   Badge,
   Button,
-  Card,
   Code,
   FileUpload,
   Flex,
@@ -24,6 +23,7 @@ import {
 import { HelpCircle, Trophy, Upload, UsersRound } from 'lucide-react';
 
 import SearchableSelect from '@/components/SearchableSelect';
+import { Card } from '@/components/ui/card';
 import { toaster } from '@/components/ui/toaster';
 import {
   PlayerSelection,
@@ -128,200 +128,197 @@ export default function RegistrationPageClient() {
 
       <SimpleGrid columns={{ base: 1, lg: 12 }} gap={6} alignItems="start">
         <GridItem colSpan={{ base: 1, lg: 5 }}>
-          <Card.Root size="sm">
-            <Card.Header>
-              <Flex justifyContent="space-between">
-                <HStack>
-                  <UsersRound size={16} />
-                  <Card.Title>Select players</Card.Title>
-                </HStack>
-                <Badge
-                  variant="surface"
-                  colorPalette={selection.length ? 'green' : 'gray'}
-                >
-                  {selection.length} selected
-                </Badge>
-              </Flex>
-              <Card.Description>
+          <Card
+            size="sm"
+            title={
+              <HStack>
+                <UsersRound size={16} />
+                Select players
+              </HStack>
+            }
+            action={
+              <Badge
+                variant="surface"
+                colorPalette={selection.length ? 'green' : 'gray'}
+              >
+                {selection.length} selected
+              </Badge>
+            }
+            description={
+              <>
                 Only <Span backgroundColor="green.100">active</Span> players are
                 shown.
-              </Card.Description>
-            </Card.Header>
-            <Card.Body>
-              <HStack alignItems="end" gap={2}>
-                <PlayerSelection
-                  disabled={isDisabled}
-                  selection={selection}
-                  onSelectionChange={setSelection}
-                />
-                <Button
-                  variant="outline"
-                  disabled={
-                    isDisabled || activePlayers.length === 0 || allSelected
-                  }
-                  onClick={() => setSelection(activePlayers)}
-                >
-                  Select all
-                </Button>
-                <Button
-                  variant="ghost"
-                  colorPalette="red"
-                  disabled={isDisabled || selection.length === 0}
-                  onClick={() => setSelection([])}
-                >
-                  Clear
-                </Button>
-              </HStack>
-
-              <SelectedPlayers
+              </>
+            }
+          >
+            <HStack alignItems="end" gap={2}>
+              <PlayerSelection
+                disabled={isDisabled}
                 selection={selection}
                 onSelectionChange={setSelection}
               />
-            </Card.Body>
-          </Card.Root>
+              <Button
+                variant="outline"
+                disabled={
+                  isDisabled || activePlayers.length === 0 || allSelected
+                }
+                onClick={() => setSelection(activePlayers)}
+              >
+                Select all
+              </Button>
+              <Button
+                variant="ghost"
+                colorPalette="red"
+                disabled={isDisabled || selection.length === 0}
+                onClick={() => setSelection([])}
+              >
+                Clear
+              </Button>
+            </HStack>
 
-          <Card.Root size="sm" marginBlock={6}>
-            <Card.Header>
+            <SelectedPlayers
+              selection={selection}
+              onSelectionChange={setSelection}
+            />
+          </Card>
+
+          <Card
+            size="sm"
+            marginBlock={6}
+            title={
               <HStack>
                 <Trophy size={16} />
-                <Card.Title>Choose a league</Card.Title>
+                Choose a league
               </HStack>
-              <Card.Description>
-                Pick which competition this registration is for.
-              </Card.Description>
-            </Card.Header>
-            <Card.Body>
-              <SearchableSelect
-                controlledMode={false}
-                multiple={false}
-                label={CACHE_KEY.LEAGUES}
-                action={getLeagues}
-                fieldProps={{ disabled: isDisabled }}
-                value={league ?? null}
-                itemToString={({ name }) => name}
-                itemToValue={({ league_id }) => league_id}
-                onChange={(item) => setLeague(item ?? undefined)}
-              />
-            </Card.Body>
-          </Card.Root>
+            }
+            description="Pick which competition this registration is for."
+          >
+            <SearchableSelect
+              controlledMode={false}
+              multiple={false}
+              label={CACHE_KEY.LEAGUES}
+              action={getLeagues}
+              fieldProps={{ disabled: isDisabled }}
+              value={league ?? null}
+              itemToString={({ name }) => name}
+              itemToValue={({ league_id }) => league_id}
+              onChange={(item) => setLeague(item ?? undefined)}
+            />
+          </Card>
 
-          <Card.Root size="sm">
-            <Card.Header>
+          <Card
+            size="sm"
+            title={
               <HStack>
                 <Upload size={16} />
-                <Card.Title>Attach PDF</Card.Title>
-                <Card.Description fontSize="xs">(optional)</Card.Description>
-                <Popover.Root>
-                  <Popover.Trigger asChild>
-                    <IconButton
-                      size="sm"
-                      variant="ghost"
-                      marginLeft="auto"
-                      colorPalette="blue"
-                    >
-                      <HelpCircle size={14} />
-                    </IconButton>
-                  </Popover.Trigger>
-                  <Portal>
-                    <Popover.Positioner>
-                      <Popover.Content>
-                        <Popover.Arrow />
-                        <Popover.Body>
-                          <Popover.Title fontWeight="medium">
-                            Field names
-                          </Popover.Title>
-                          <Text fontSize="xs" color="fg.muted" marginTop={1}>
-                            Upload a fillable PDF whose text fields are named
-                            like below — they&apos;ll be filled automatically.
-                          </Text>
-                          <Stack gap={2} marginTop={3}>
-                            {FIELD_GUIDE.map(({ label, names }) => (
-                              <Flex
-                                key={label}
-                                justifyContent="space-between"
-                                alignItems="center"
-                                gap={3}
-                              >
-                                <Span fontSize="xs" fontWeight="medium">
-                                  {label}
-                                </Span>
-                                <HStack
-                                  gap={1}
-                                  flexWrap="wrap"
-                                  justifyContent="end"
-                                >
-                                  {names.map((name) => (
-                                    <Code key={name} size="sm">
-                                      {name}
-                                    </Code>
-                                  ))}
-                                </HStack>
-                              </Flex>
-                            ))}
-                          </Stack>
-                        </Popover.Body>
-                        <Popover.Footer fontSize="xs" color="fg.muted">
-                          No fillable fields? We&apos;ll generate a roster from
-                          scratch instead.
-                        </Popover.Footer>
-                      </Popover.Content>
-                    </Popover.Positioner>
-                  </Portal>
-                </Popover.Root>
-              </HStack>
-              <Card.Description>
-                Upload a fillable PDF form or auto-generate a roster for the
-                current league.
-              </Card.Description>
-            </Card.Header>
-            <Card.Body>
-              <FileUpload.Root
-                accept="application/pdf"
-                maxFiles={1}
-                maxFileSize={10 * 1024 * 1024}
-                disabled={isDisabled}
-                onFileChange={({ acceptedFiles }) =>
-                  setTemplate(acceptedFiles[0])
-                }
-              >
-                <FileUpload.HiddenInput />
-                {!template && (
-                  <FileUpload.Dropzone width="full" minHeight="20">
-                    <Upload size={16} />
-                    <FileUpload.DropzoneContent>
-                      <Span>Click to upload PDF</Span>
-                      <Span color="fg.muted" fontSize="xs">
-                        Max 10 MB
-                      </Span>
-                    </FileUpload.DropzoneContent>
-                  </FileUpload.Dropzone>
-                )}
-                <FileUpload.List clearable />
-              </FileUpload.Root>
-
-              <HStack marginBlock={2}>
-                <Span fontWeight="medium" fontSize="sm">
-                  Notes
-                </Span>
+                Attach PDF
                 <Span fontSize="xs" color="fg.muted">
                   (optional)
                 </Span>
-                <Span fontSize="xs" color="fg.muted" marginLeft="auto">
-                  {notes.length}/{NOTES_LIMIT}
-                </Span>
               </HStack>
-              <Textarea
-                size="sm"
-                rows={3}
-                resize="none"
-                value={notes}
-                disabled={isDisabled}
-                maxLength={NOTES_LIMIT}
-                placeholder="Internal notes about this registration…"
-                onChange={(event) => setNotes(event.target.value)}
-              />
-            </Card.Body>
-          </Card.Root>
+            }
+            action={
+              <Popover.Root>
+                <Popover.Trigger asChild>
+                  <IconButton size="sm" variant="ghost" colorPalette="blue">
+                    <HelpCircle size={14} />
+                  </IconButton>
+                </Popover.Trigger>
+                <Portal>
+                  <Popover.Positioner>
+                    <Popover.Content>
+                      <Popover.Arrow />
+                      <Popover.Body>
+                        <Popover.Title fontWeight="medium">
+                          Field names
+                        </Popover.Title>
+                        <Text fontSize="xs" color="fg.muted" marginTop={1}>
+                          Upload a fillable PDF whose text fields are named like
+                          below — they&apos;ll be filled automatically.
+                        </Text>
+                        <Stack gap={2} marginTop={3}>
+                          {FIELD_GUIDE.map(({ label, names }) => (
+                            <Flex
+                              key={label}
+                              justifyContent="space-between"
+                              alignItems="center"
+                              gap={3}
+                            >
+                              <Span fontSize="xs" fontWeight="medium">
+                                {label}
+                              </Span>
+                              <HStack
+                                gap={1}
+                                flexWrap="wrap"
+                                justifyContent="end"
+                              >
+                                {names.map((name) => (
+                                  <Code key={name} size="sm">
+                                    {name}
+                                  </Code>
+                                ))}
+                              </HStack>
+                            </Flex>
+                          ))}
+                        </Stack>
+                      </Popover.Body>
+                      <Popover.Footer fontSize="xs" color="fg.muted">
+                        No fillable fields? We&apos;ll generate a roster from
+                        scratch instead.
+                      </Popover.Footer>
+                    </Popover.Content>
+                  </Popover.Positioner>
+                </Portal>
+              </Popover.Root>
+            }
+            description="Upload a fillable PDF form or auto-generate a roster for the current league."
+          >
+            <FileUpload.Root
+              accept="application/pdf"
+              maxFiles={1}
+              maxFileSize={10 * 1024 * 1024}
+              disabled={isDisabled}
+              onFileChange={({ acceptedFiles }) =>
+                setTemplate(acceptedFiles[0])
+              }
+            >
+              <FileUpload.HiddenInput />
+              {!template && (
+                <FileUpload.Dropzone width="full" minHeight="20">
+                  <Upload size={16} />
+                  <FileUpload.DropzoneContent>
+                    <Span>Click to upload PDF</Span>
+                    <Span color="fg.muted" fontSize="xs">
+                      Max 10 MB
+                    </Span>
+                  </FileUpload.DropzoneContent>
+                </FileUpload.Dropzone>
+              )}
+              <FileUpload.List clearable />
+            </FileUpload.Root>
+
+            <HStack marginBlock={2}>
+              <Span fontWeight="medium" fontSize="sm">
+                Notes
+              </Span>
+              <Span fontSize="xs" color="fg.muted">
+                (optional)
+              </Span>
+              <Span fontSize="xs" color="fg.muted" marginLeft="auto">
+                {notes.length}/{NOTES_LIMIT}
+              </Span>
+            </HStack>
+            <Textarea
+              size="sm"
+              rows={3}
+              resize="none"
+              value={notes}
+              disabled={isDisabled}
+              maxLength={NOTES_LIMIT}
+              placeholder="Internal notes about this registration…"
+              onChange={(event) => setNotes(event.target.value)}
+            />
+          </Card>
         </GridItem>
 
         <GridItem colSpan={{ base: 1, lg: 7 }}>

--- a/src/app/(protected)/profile/_components/PersonalInfo.tsx
+++ b/src/app/(protected)/profile/_components/PersonalInfo.tsx
@@ -71,11 +71,6 @@ export default function PersonalInfo({
   return (
     <Card
       as="form"
-      size="sm"
-      _hover={{
-        shadow: 'md',
-        transition: 'all 0.2s',
-      }}
       onSubmit={handleSubmit(onSubmit)}
       title="Personal Information"
       action={

--- a/src/app/(protected)/profile/_components/PersonalInfo.tsx
+++ b/src/app/(protected)/profile/_components/PersonalInfo.tsx
@@ -2,12 +2,13 @@
 
 import { useState, useTransition } from 'react';
 
-import { Card, HStack, IconButton, Input, SimpleGrid } from '@chakra-ui/react';
+import { IconButton, Input, SimpleGrid } from '@chakra-ui/react';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Edit, Save } from 'lucide-react';
 import { useForm } from 'react-hook-form';
 
 import TextField from '@/components/TextField';
+import { Card } from '@/components/ui/card';
 import { CloseButton } from '@/components/ui/close-button';
 import { Field } from '@/components/ui/field';
 import { toaster } from '@/components/ui/toaster';
@@ -68,7 +69,7 @@ export default function PersonalInfo({
   };
 
   return (
-    <Card.Root
+    <Card
       as="form"
       size="sm"
       _hover={{
@@ -76,113 +77,104 @@ export default function PersonalInfo({
         transition: 'all 0.2s',
       }}
       onSubmit={handleSubmit(onSubmit)}
-    >
-      <HStack
-        borderBottom={1}
-        borderBottomStyle="solid"
-        borderBottomColor="gray.200"
-        asChild
-      >
-        <Card.Header paddingBlock={2}>
-          <Card.Title marginRight="auto">Personal Information</Card.Title>
-          {isEditing ? (
-            <>
-              <CloseButton size="sm" variant="outline" onClick={onCancel} />
-              <Tooltip content="Save" disabled={isPending}>
-                <IconButton
-                  size="sm"
-                  type="submit"
-                  disabled={!isDirty || !isValid || isPending}
-                >
-                  <Save />
-                </IconButton>
-              </Tooltip>
-            </>
-          ) : (
-            <Tooltip content={viewOnly ? 'View Only' : 'Edit'}>
+      title="Personal Information"
+      action={
+        isEditing ? (
+          <>
+            <CloseButton size="sm" variant="outline" onClick={onCancel} />
+            <Tooltip content="Save" disabled={isPending}>
               <IconButton
                 size="sm"
-                variant="subtle"
-                disabled={viewOnly}
-                onClick={() => setIsEditing(true)}
+                type="submit"
+                disabled={!isDirty || !isValid || isPending}
               >
-                <Edit />
+                <Save />
               </IconButton>
             </Tooltip>
-          )}
-        </Card.Header>
-      </HStack>
-      <Card.Body>
-        <SimpleGrid
-          columns={{
-            base: 1,
-            md: 2,
-            xl: 3,
-          }}
-          gap={4}
-        >
-          {isEditing ? (
-            <>
-              <Field label="Email">
-                <Input variant="flushed" value={user.email} disabled />
-              </Field>
-              <Field
-                required
-                label="Fullname"
-                invalid={!!errors.name}
-                errorText={errors.name?.message}
-              >
-                <Input
-                  placeholder="Anonymous"
-                  disabled={isPending}
-                  {...register('name')}
-                />
-              </Field>
-              <Field
-                label="DOB"
-                invalid={!!errors.dob}
-                errorText={errors.dob?.message}
-              >
-                <Input
-                  type="date"
-                  min="1997-01-01"
-                  disabled={isPending}
-                  {...register('dob')}
-                />
-              </Field>
-              <Field
-                label="Phone Number"
-                invalid={!!errors.phone_number}
-                errorText={errors.phone_number?.message}
-              >
-                <Input disabled={isPending} {...register('phone_number')} />
-              </Field>
-              <Field
-                label="Citizen ID"
-                invalid={!!errors.citizen_identification}
-                errorText={errors.citizen_identification?.message}
-              >
-                <Input
-                  disabled={isPending}
-                  {...register('citizen_identification')}
-                />
-              </Field>
-            </>
-          ) : (
-            <>
-              <TextField label="Email">{user.email}</TextField>
-              <TextField label="Fullname">{user.name || '-'}</TextField>
-              <TextField label="DOB">{formatDate(user.dob) || '-'}</TextField>
-              <TextField label="Phone Number">
-                {user.phone_number || '-'}
-              </TextField>
-              <TextField label="Citizen ID">
-                {user.citizen_identification || '-'}
-              </TextField>
-            </>
-          )}
-        </SimpleGrid>
-      </Card.Body>
-    </Card.Root>
+          </>
+        ) : (
+          <Tooltip content={viewOnly ? 'View Only' : 'Edit'}>
+            <IconButton
+              size="sm"
+              variant="subtle"
+              disabled={viewOnly}
+              onClick={() => setIsEditing(true)}
+            >
+              <Edit />
+            </IconButton>
+          </Tooltip>
+        )
+      }
+    >
+      <SimpleGrid
+        columns={{
+          base: 1,
+          md: 2,
+          xl: 3,
+        }}
+        gap={4}
+      >
+        {isEditing ? (
+          <>
+            <Field label="Email">
+              <Input variant="flushed" value={user.email} disabled />
+            </Field>
+            <Field
+              required
+              label="Fullname"
+              invalid={!!errors.name}
+              errorText={errors.name?.message}
+            >
+              <Input
+                placeholder="Anonymous"
+                disabled={isPending}
+                {...register('name')}
+              />
+            </Field>
+            <Field
+              label="DOB"
+              invalid={!!errors.dob}
+              errorText={errors.dob?.message}
+            >
+              <Input
+                type="date"
+                min="1997-01-01"
+                disabled={isPending}
+                {...register('dob')}
+              />
+            </Field>
+            <Field
+              label="Phone Number"
+              invalid={!!errors.phone_number}
+              errorText={errors.phone_number?.message}
+            >
+              <Input disabled={isPending} {...register('phone_number')} />
+            </Field>
+            <Field
+              label="Citizen ID"
+              invalid={!!errors.citizen_identification}
+              errorText={errors.citizen_identification?.message}
+            >
+              <Input
+                disabled={isPending}
+                {...register('citizen_identification')}
+              />
+            </Field>
+          </>
+        ) : (
+          <>
+            <TextField label="Email">{user.email}</TextField>
+            <TextField label="Fullname">{user.name || '-'}</TextField>
+            <TextField label="DOB">{formatDate(user.dob) || '-'}</TextField>
+            <TextField label="Phone Number">
+              {user.phone_number || '-'}
+            </TextField>
+            <TextField label="Citizen ID">
+              {user.citizen_identification || '-'}
+            </TextField>
+          </>
+        )}
+      </SimpleGrid>
+    </Card>
   );
 }

--- a/src/app/(protected)/profile/_components/TeamInfo.tsx
+++ b/src/app/(protected)/profile/_components/TeamInfo.tsx
@@ -5,7 +5,6 @@ import { useSWRConfig } from 'swr';
 
 import {
   Badge,
-  HStack,
   IconButton,
   Input,
   InputGroup,
@@ -119,10 +118,6 @@ export default function TeamInfo({
     <Card
       as="form"
       size="sm"
-      _hover={{
-        shadow: 'md',
-        transition: 'all 0.2s',
-      }}
       onSubmit={handleSubmit(onSubmit)}
       title="Team Information"
       action={

--- a/src/app/(protected)/profile/_components/TeamInfo.tsx
+++ b/src/app/(protected)/profile/_components/TeamInfo.tsx
@@ -5,12 +5,12 @@ import { useSWRConfig } from 'swr';
 
 import {
   Badge,
-  Card,
   HStack,
   IconButton,
   Input,
   InputGroup,
   SimpleGrid,
+  Stack,
   Text,
 } from '@chakra-ui/react';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -19,6 +19,7 @@ import { Activity, Edit, LucideClock9, Save, Shirt } from 'lucide-react';
 import { Controller, useForm } from 'react-hook-form';
 
 import TextField from '@/components/TextField';
+import { Card } from '@/components/ui/card';
 import { CloseButton } from '@/components/ui/close-button';
 import { Field } from '@/components/ui/field';
 import {
@@ -115,7 +116,7 @@ export default function TeamInfo({
   };
 
   return (
-    <Card.Root
+    <Card
       as="form"
       size="sm"
       _hover={{
@@ -123,43 +124,36 @@ export default function TeamInfo({
         transition: 'all 0.2s',
       }}
       onSubmit={handleSubmit(onSubmit)}
-    >
-      <HStack
-        borderBottom={1}
-        borderBottomStyle="solid"
-        borderBottomColor="gray.200"
-        asChild
-      >
-        <Card.Header paddingBlock={2}>
-          <Card.Title marginRight="auto">Team Information</Card.Title>
-          {isEditing ? (
-            <>
-              <CloseButton size="sm" variant="outline" onClick={onCancel} />
-              <Tooltip content="Save" disabled={isPending}>
-                <IconButton
-                  size="sm"
-                  type="submit"
-                  disabled={!isDirty || !isValid || isPending}
-                >
-                  <Save />
-                </IconButton>
-              </Tooltip>
-            </>
-          ) : (
-            <Tooltip content={viewOnly ? 'View Only' : 'Edit'}>
+      title="Team Information"
+      action={
+        isEditing ? (
+          <>
+            <CloseButton size="sm" variant="outline" onClick={onCancel} />
+            <Tooltip content="Save" disabled={isPending}>
               <IconButton
                 size="sm"
-                variant="subtle"
-                disabled={viewOnly}
-                onClick={() => setIsEditing(true)}
+                type="submit"
+                disabled={!isDirty || !isValid || isPending}
               >
-                <Edit />
+                <Save />
               </IconButton>
             </Tooltip>
-          )}
-        </Card.Header>
-      </HStack>
-      <Card.Body gap={3}>
+          </>
+        ) : (
+          <Tooltip content={viewOnly ? 'View Only' : 'Edit'}>
+            <IconButton
+              size="sm"
+              variant="subtle"
+              disabled={viewOnly}
+              onClick={() => setIsEditing(true)}
+            >
+              <Edit />
+            </IconButton>
+          </Tooltip>
+        )
+      }
+    >
+      <Stack gap={3}>
         {isEditing && isAdmin ? (
           <RolePositionSelection
             roleName="user.role"
@@ -284,7 +278,7 @@ export default function TeamInfo({
             )}
           </>
         )}
-      </Card.Body>
-    </Card.Root>
+      </Stack>
+    </Card>
   );
 }

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,23 +1,40 @@
 import { ReactNode } from 'react';
 
-import { Card as ChakraCard } from '@chakra-ui/react';
+import { Card as ChakraCard, Flex } from '@chakra-ui/react';
 
 export interface CardProps extends Omit<ChakraCard.RootProps, 'title'> {
   title: ReactNode;
   description?: ReactNode;
+  action?: ReactNode;
+  footer?: ReactNode;
   children?: ReactNode;
 }
 
-export function Card({ title, description, children, ...rest }: CardProps) {
+export function Card({
+  title,
+  description,
+  action,
+  footer,
+  children,
+  ...rest
+}: CardProps) {
   return (
     <ChakraCard.Root {...rest}>
       <ChakraCard.Header>
-        <ChakraCard.Title>{title}</ChakraCard.Title>
+        {action ? (
+          <Flex justifyContent="space-between" alignItems="center" gap={2}>
+            <ChakraCard.Title>{title}</ChakraCard.Title>
+            {action}
+          </Flex>
+        ) : (
+          <ChakraCard.Title>{title}</ChakraCard.Title>
+        )}
         {description && (
           <ChakraCard.Description>{description}</ChakraCard.Description>
         )}
       </ChakraCard.Header>
       <ChakraCard.Body>{children}</ChakraCard.Body>
+      {footer && <ChakraCard.Footer>{footer}</ChakraCard.Footer>}
     </ChakraCard.Root>
   );
 }

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,14 +1,15 @@
-import { ReactNode } from 'react';
+import { Card as ChakraCard, HStack } from '@chakra-ui/react';
 
-import { Card as ChakraCard, Flex } from '@chakra-ui/react';
-
-export interface CardProps extends Omit<ChakraCard.RootProps, 'title'> {
-  title: ReactNode;
-  description?: ReactNode;
-  action?: ReactNode;
-  footer?: ReactNode;
-  children?: ReactNode;
-}
+export type CardProps = Omit<ChakraCard.RootProps, 'title'> &
+  Required<{
+    title: React.ReactNode;
+  }> &
+  Partial<{
+    description: React.ReactNode;
+    action: React.ReactNode;
+    footer: React.ReactNode;
+    children: React.ReactNode;
+  }>;
 
 export function Card({
   title,
@@ -19,13 +20,13 @@ export function Card({
   ...rest
 }: CardProps) {
   return (
-    <ChakraCard.Root {...rest}>
+    <ChakraCard.Root {...rest} size="sm">
       <ChakraCard.Header>
         {action ? (
-          <Flex justifyContent="space-between" alignItems="center" gap={2}>
+          <HStack justifyContent="space-between" alignItems="start">
             <ChakraCard.Title>{title}</ChakraCard.Title>
             {action}
-          </Flex>
+          </HStack>
         ) : (
           <ChakraCard.Title>{title}</ChakraCard.Title>
         )}


### PR DESCRIPTION
#### Improvements 🙌

- Enhance the reusable Card component to support action (header-right content) and footer slots.
- Replace Chakra `Card.Root`/`Card.Header`/`Card.Body`/`Card.Footer` compositions with the reusable Card API across several profile, registration, overview dashboard, and periodic testing components.
- Simplified component structure by moving header title/description/action concerns into Card props and leaving main content as children.

_Resolve #206_
