### PR TITLE
Analytics Reports (Phase 2): Report persistence + email distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@
 - 🔑 [Better Auth](https://www.better-auth.com) for authentication.
 - 📩 [Resend](https://resend.com/) for email confirmation.
 - ⏰ [date-fns](https://date-fns.org/) for datetime manipulation.
+- PDF generation with:
+  - [pdf-lib](https://pdf-lib.js.org/) for PDF manipulation.
+  - [js-byte64](https://www.npmjs.com/package/js-base64) for base64 encoding/decoding.
 - 💃 Using various parts of a modern frontend stack:
   - [Chakra UI](https://chakra-ui.com/) for component library.
   - [zod](https://zod.dev/) and [React Hook Form](https://react-hook-form.com/) for schema validation.

--- a/env.config.ts
+++ b/env.config.ts
@@ -14,6 +14,12 @@ const envSchema = z.object({
   PRODUCTION_URL: z.url().default('http://localhost:3000'),
   DATABASE_URL: z.string().default(''),
   RESEND_API_KEY: z.string().default(''),
+  BLOB_READ_WRITE_TOKEN: z
+    .string()
+    .default('')
+    .describe(
+      'Read/write token for the Vercel Blob store. Required to persist generated reports.',
+    ),
   CHROMIUM_PACK_URL: z
     .string()
     .default('')

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "eslint": "^9.39.2",
     "eslint-config-next": "16.2.2",
     "jest-axe": "^10.0.0",
+    "js-base64": "^3.8.0",
     "jsdom": "^27.4.0",
     "tsx": "^4.21.0",
     "typescript": "^6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,6 +150,9 @@ importers:
       jest-axe:
         specifier: ^10.0.0
         version: 10.0.0
+      js-base64:
+        specifier: ^3.8.0
+        version: 3.8.0
       jsdom:
         specifier: ^27.4.0
         version: 27.4.0(@noble/hashes@2.2.0)
@@ -3495,6 +3498,9 @@ packages:
 
   jose@6.2.3:
     resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
+  js-base64@3.8.0:
+    resolution: {integrity: sha512-65kvbemyZhj+ExQt1PEFyBEjL5vAHysu1lJdW1AwhhChkO8ZBPizYk/m9GVrpbS2Je1hF+UYZ+6KywqtZV8mHw==}
 
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
@@ -8269,6 +8275,8 @@ snapshots:
       picomatch: 4.0.4
 
   jose@6.2.3: {}
+
+  js-base64@3.8.0: {}
 
   js-tokens@10.0.0: {}
 

--- a/src/actions/asset.test.ts
+++ b/src/actions/asset.test.ts
@@ -88,7 +88,7 @@ describe('Asset Actions', () => {
 
     test('returns empty response when no assets exist', async () => {
       const emptyResponse = {
-        stats: { total_items: 0, need_replacement: 0 },
+        stats: { total_items: 0, need_replacement: 0, obsolete_count: 0 },
         data: [],
       };
       vi.mocked(getDbAssets).mockResolvedValue(emptyResponse);

--- a/src/actions/report.test.ts
+++ b/src/actions/report.test.ts
@@ -1,0 +1,96 @@
+import { fetchReportRecipients } from '@/db/report';
+import { sendEmail, type EmailProps } from '@/lib/resend';
+
+import { mockWithAuth } from '@/test/mocks/auth';
+import { MOCK_TEAM } from '@/test/mocks/team';
+
+import { UserRole } from '@/utils/enum';
+
+import { getReportRecipients, sendReportEmail } from './report';
+
+vi.mock('./auth', () => ({
+  withAuth: mockWithAuth,
+}));
+
+vi.mock('@/db/report', () => ({
+  fetchReportRecipients: vi.fn(),
+}));
+
+vi.mock('@/lib/resend', () => ({
+  sendEmail: vi.fn(),
+}));
+
+const MOCK_RECIPIENTS = [
+  {
+    id: 'user-123',
+    name: 'Dios Vo',
+    email: 'vtmn1212@gmail.com',
+    role: UserRole.COACH,
+  },
+  {
+    id: 'user-456',
+    name: 'Jane Doe',
+    email: 'jane@example.com',
+    role: UserRole.PLAYER,
+  },
+];
+
+describe('Report Actions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getReportRecipients', () => {
+    test('calls fetchReportRecipients with team_id', async () => {
+      vi.mocked(fetchReportRecipients).mockResolvedValue(MOCK_RECIPIENTS);
+
+      const result = await getReportRecipients();
+
+      expect(fetchReportRecipients).toHaveBeenCalledWith(MOCK_TEAM.team_id);
+      expect(result).toEqual(MOCK_RECIPIENTS);
+    });
+
+    test('returns empty array when no recipients exist', async () => {
+      vi.mocked(fetchReportRecipients).mockResolvedValue([]);
+
+      const result = await getReportRecipients();
+
+      expect(result).toEqual([]);
+    });
+
+    test('propagates errors from fetchReportRecipients', async () => {
+      const message = 'Database error';
+      vi.mocked(fetchReportRecipients).mockRejectedValue(new Error(message));
+
+      await expect(getReportRecipients()).rejects.toThrow(message);
+    });
+  });
+
+  describe('sendReportEmail', () => {
+    const PAYLOAD: EmailProps = {
+      to: ['coach@example.com'],
+      subject: 'Weekly Report',
+      html: '<p>Report</p>',
+      attachments: [{ content: 'base64', filename: 'report.pdf' }],
+    };
+
+    test('calls sendEmail with the payload and returns the response', async () => {
+      const response = { data: { id: 'email-id' }, error: null };
+      vi.mocked(sendEmail).mockResolvedValue(
+        response as Awaited<ReturnType<typeof sendEmail>>,
+      );
+
+      const result = await sendReportEmail(PAYLOAD);
+
+      expect(sendEmail).toHaveBeenCalledWith(PAYLOAD);
+      expect(result).toEqual(response);
+    });
+
+    test('propagates errors from sendEmail', async () => {
+      const message = 'network down';
+      vi.mocked(sendEmail).mockRejectedValue(new Error(message));
+
+      await expect(sendReportEmail(PAYLOAD)).rejects.toThrow(message);
+    });
+  });
+});

--- a/src/actions/report.ts
+++ b/src/actions/report.ts
@@ -1,0 +1,15 @@
+'use server';
+
+import { fetchReportRecipients } from '@/db/report';
+import { sendEmail, type EmailProps } from '@/lib/resend';
+
+import { withAuth } from './auth';
+
+export const getReportRecipients = withAuth(async ({ team_id }) => {
+  if (!team_id) return [];
+  return await fetchReportRecipients(team_id);
+});
+
+export const sendReportEmail = withAuth(
+  async (_user, payload: EmailProps) => await sendEmail(payload),
+);

--- a/src/app/(auth)/_components/ResetPassword.tsx
+++ b/src/app/(auth)/_components/ResetPassword.tsx
@@ -1,41 +1,32 @@
+import EmailLayout from '@/components/common/EmailLayout';
+
 type ResetPasswordProps = {
   name: string;
   url: string;
 };
 
-const YEAR = new Date().getFullYear();
+export default function ResetPassword({
+  name,
+  url,
+}: ResetPasswordProps): string {
+  return EmailLayout(
+    `<p style="font-size: 14px; margin-bottom: 16px">
+      Hi <strong>${name}</strong>,
+    </p>
+    <p style="font-size: 14px; margin-bottom: 24px">
+      Click the button below to create a new password. If you did not request this, you can ignore this email.
+    </p>
 
-export default function ResetPassword({ name, url }: ResetPasswordProps) {
-  return `<div style="max-width: 560px; margin: 0 auto; padding: 24px; border: 1px solid #e2e8f0; border-radius: 6px;">
-    <div style="margin-bottom: 16px">
-      <img src="https://sgr-portal.vercel.app/logo.svg" alt="Saigon Rovers Basketball Club" />
-    </div>
-
-    <hr style="border: none; border-top: 1px solid #e2e8f0; margin: 0" />
-
-    <div style="margin-top: 16px; margin-bottom: 32px">
-      <p style="font-size: 14px; margin-bottom: 16px">
-        Hi <strong>${name}</strong>,
+    <div style="width: 100%; border: 1px dashed #e2e8f0; border-radius: 6px; text-align: center; padding-top: 16px; padding-bottom: 16px;">
+      <a
+        href="${url}"
+        style="display: inline-block; background-color: #8c271e; color: white; padding: 8px 16px; border-radius: 4px; font-size: 14px; text-decoration: none;"
+      >
+        Create new password
+      </a>
+      <p style="font-size: 10px; margin-top: 8px; margin-bottom: 0; color: #718096;">
+        This link will be valid for 1 hour.
       </p>
-      <p style="font-size: 14px; margin-bottom: 24px">
-        Click the button below to create a new password. If you did not request this, you can ignore this email.
-      </p>
-
-      <div style="width: 100%; border: 1px dashed #e2e8f0; border-radius: 6px; text-align: center; padding-top: 16px; padding-bottom: 16px;">
-        <a 
-          href="${url}"
-          style="display: inline-block; background-color: #8c271e; color: white; padding: 8px 16px; border-radius: 4px; font-size: 14px; text-decoration: none;"
-        >
-          Create new password
-        </a>
-        <p style="font-size: 10px; margin-top: 8px; margin-bottom: 0; color: #718096;">
-          This link will be valid for 1 hour.
-        </p>
-      </div>
-    </div>
-
-    <div style="color: #718096; font-size: 12px; text-align: center;">
-      <p>© ${YEAR} Saigon Rovers Basketball Club</p>
-    </div>
-  </div>`;
+    </div>`,
+  );
 }

--- a/src/app/(protected)/(overview)/dashboard/_components/AttendanceTrend.tsx
+++ b/src/app/(protected)/(overview)/dashboard/_components/AttendanceTrend.tsx
@@ -93,7 +93,7 @@ export default function AttendanceTrend({
               stroke="orange"
               strokeDasharray="2 2"
               label={{
-                value: `Target (${TARGET_RATE})`,
+                value: `Target (${TARGET_RATE})%`,
                 position: 'top',
               }}
             />

--- a/src/app/(protected)/(overview)/dashboard/_components/DashboardFilters.test.tsx
+++ b/src/app/(protected)/(overview)/dashboard/_components/DashboardFilters.test.tsx
@@ -6,8 +6,17 @@ import { toaster } from '@/components/ui/toaster';
 import { triggerDownload } from '@/lib/download';
 import { renderWithUI, screen, waitFor } from '@/test/utilities';
 import { Interval } from '@/utils/enum';
+import { formatDuration } from '@/utils/formatter';
 
 import DashboardFilters from './DashboardFilters';
+
+// Mirror the payload the component derives from the selected interval so the
+// expectations stay correct regardless of the year the suite runs in.
+const expectedPayload = (interval: Interval) => {
+  const period = formatDuration(interval);
+  const filename = `sgr-report-${period.replace(/\D+/g, '-')}.pdf`;
+  return { period, filename };
+};
 
 vi.mock('@/lib/download', () => ({
   triggerDownload: vi.fn(),
@@ -30,13 +39,13 @@ describe('DashboardFilters', () => {
       mockSetSearchParams,
     ]);
 
-    const view = renderWithUI(<DashboardFilters />);
-    const downloadButton = screen.getByRole('button', { name: /Download/ });
+    return renderWithUI(<DashboardFilters />);
+  };
 
-    return {
-      ...view,
-      downloadButton,
-    };
+  // Download lives behind the Actions menu — open it, then click the item.
+  const clickDownload = async (user: ReturnType<typeof setup>['user']) => {
+    await user.click(screen.getByRole('button', { name: /Actions/i }));
+    await user.click(await screen.findByRole('menuitem', { name: /Download/i }));
   };
 
   beforeEach(() => {
@@ -48,10 +57,12 @@ describe('DashboardFilters', () => {
     vi.unstubAllGlobals();
   });
 
-  test('renders the download button and the selected interval', () => {
-    const { downloadButton } = setup();
+  test('renders the actions menu and the selected interval', () => {
+    setup();
 
-    expect(downloadButton).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Actions/i }),
+    ).toBeInTheDocument();
     expect(screen.getByRole('combobox')).toBeInTheDocument();
     expect(screen.getAllByText('This year').length).toBeGreaterThan(0);
   });
@@ -64,23 +75,19 @@ describe('DashboardFilters', () => {
         blob: vi.fn().mockResolvedValue(blob),
       });
 
-      const { user, downloadButton } = setup();
-      await user.click(downloadButton);
+      const { user } = setup();
+      await clickDownload(user);
+
+      const { period, filename } = expectedPayload(Interval.THIS_YEAR);
 
       await waitFor(() => {
         expect(mockFetch).toHaveBeenCalledWith('/api/reports/dashboard', {
           method: 'POST',
-          body: JSON.stringify({
-            interval: Interval.THIS_YEAR,
-            filename: 'analytics-overview-report.pdf',
-          }),
+          body: JSON.stringify({ period, filename }),
         });
       });
 
-      expect(triggerDownload).toHaveBeenCalledWith(
-        blob,
-        'analytics-overview-report.pdf',
-      );
+      expect(triggerDownload).toHaveBeenCalledWith(blob, filename);
       expect(toaster.error).not.toHaveBeenCalled();
     });
 
@@ -91,17 +98,16 @@ describe('DashboardFilters', () => {
         blob: vi.fn().mockResolvedValue(blob),
       });
 
-      const { user, downloadButton } = setup({ interval: Interval.LAST_YEAR });
-      await user.click(downloadButton);
+      const { user } = setup({ interval: Interval.LAST_YEAR });
+      await clickDownload(user);
+
+      const { period, filename } = expectedPayload(Interval.LAST_YEAR);
 
       await waitFor(() => {
         expect(mockFetch).toHaveBeenCalledWith(
           '/api/reports/dashboard',
           expect.objectContaining({
-            body: JSON.stringify({
-              interval: Interval.LAST_YEAR,
-              filename: 'analytics-overview-report.pdf',
-            }),
+            body: JSON.stringify({ period, filename }),
           }),
         );
       });
@@ -113,8 +119,8 @@ describe('DashboardFilters', () => {
         json: vi.fn().mockResolvedValue({ error: 'Something went wrong' }),
       });
 
-      const { user, downloadButton } = setup();
-      await user.click(downloadButton);
+      const { user } = setup();
+      await clickDownload(user);
 
       await waitFor(() => {
         expect(toaster.error).toHaveBeenCalledWith({
@@ -135,8 +141,8 @@ describe('DashboardFilters', () => {
         }),
       );
 
-      const { user, downloadButton } = setup();
-      await user.click(downloadButton);
+      const { user } = setup();
+      await clickDownload(user);
 
       expect(await screen.findByText('Generating...')).toBeInTheDocument();
 

--- a/src/app/(protected)/(overview)/dashboard/_components/DashboardFilters.tsx
+++ b/src/app/(protected)/(overview)/dashboard/_components/DashboardFilters.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { Button, HStack } from '@chakra-ui/react';
-import { FileDown } from 'lucide-react';
+import { Button, HStack, Menu, Portal } from '@chakra-ui/react';
+import { ChevronDown, FileDown, Send } from 'lucide-react';
 import { useState } from 'react';
 
 import TimePicker from '@/components/filters/TimePicker';
@@ -9,12 +9,19 @@ import { toaster } from '@/components/ui/toaster';
 
 import { triggerDownload } from '@/lib/download';
 import { MatchSearchParamsKeys, useDashboardFilters } from '@/lib/nuqs';
+import { formatDuration } from '@/utils/formatter';
 
-const FILE_NAME = 'analytics-overview-report.pdf';
+import EmailReport from './EmailReport';
 
 export default function DashboardFilters() {
   const [{ interval }, setSearchParams] = useDashboardFilters();
   const [downloading, setDownloading] = useState(false);
+  const [open, setOpen] = useState(false);
+
+  const formattedPeriod = formatDuration(interval);
+  // Collapse non-digit runs (the "/" in dates and the " - " separator) into a
+  // single dash so the OS doesn't rewrite illegal "/" characters to "_".
+  const filename = `sgr-report-${formattedPeriod.replace(/\D+/g, '-')}.pdf`;
 
   const handleSearchParams = (key: MatchSearchParamsKeys, value: string) => {
     setSearchParams({ [key]: value, page: 1 }, { shallow: false });
@@ -25,7 +32,7 @@ export default function DashboardFilters() {
     try {
       const response = await fetch('/api/reports/dashboard', {
         method: 'POST',
-        body: JSON.stringify({ interval, filename: FILE_NAME }),
+        body: JSON.stringify({ period: formattedPeriod, filename }),
       });
 
       if (!response.ok) {
@@ -38,28 +45,61 @@ export default function DashboardFilters() {
       }
 
       const blob = await response.blob();
-      triggerDownload(blob, FILE_NAME);
+      triggerDownload(blob, filename);
     } finally {
       setDownloading(false);
     }
   };
 
   return (
-    <HStack>
-      <Button
-        variant="outline"
-        colorPalette="blue"
-        loading={downloading}
-        loadingText="Generating..."
-        onClick={handleDownload}
-      >
-        <FileDown /> Download
-      </Button>
+    <>
+      <HStack>
+        <Menu.Root>
+          <Menu.Trigger asChild>
+            <Button
+              variant="outline"
+              colorPalette="blue"
+              loading={downloading}
+              loadingText="Generating..."
+            >
+              Actions <ChevronDown />
+            </Button>
+          </Menu.Trigger>
+          <Portal>
+            <Menu.Positioner>
+              <Menu.Content>
+                <Menu.Item
+                  value="download"
+                  _hover={{ cursor: 'pointer' }}
+                  onClick={handleDownload}
+                >
+                  <FileDown size={14} /> Download
+                </Menu.Item>
+                <Menu.Item
+                  value="email"
+                  _hover={{ cursor: 'pointer' }}
+                  onClick={() => setOpen(true)}
+                >
+                  <Send size={14} /> Send to...
+                </Menu.Item>
+              </Menu.Content>
+            </Menu.Positioner>
+          </Portal>
+        </Menu.Root>
 
-      <TimePicker
-        value={interval}
-        onChange={(value) => handleSearchParams('interval', value)}
+        <TimePicker
+          value={interval}
+          onChange={(value) => handleSearchParams('interval', value)}
+        />
+      </HStack>
+
+      <EmailReport
+        open={open}
+        interval={interval}
+        filename={filename}
+        formattedPeriod={formattedPeriod}
+        onOpenChange={setOpen}
       />
-    </HStack>
+    </>
   );
 }

--- a/src/app/(protected)/(overview)/dashboard/_components/EmailReport.test.tsx
+++ b/src/app/(protected)/(overview)/dashboard/_components/EmailReport.test.tsx
@@ -1,0 +1,191 @@
+import { useController } from 'react-hook-form';
+
+import { toaster } from '@/components/ui/toaster';
+
+import { renderWithUI, screen, waitFor } from '@/test/utilities';
+import { Interval } from '@/utils/enum';
+
+import { sendReportEmail } from '@/actions/report';
+
+import EmailReport from './EmailReport';
+
+const RECIPIENTS = ['alice@example.com', 'bob@example.com'];
+
+// Drive the recipients field directly instead of exercising the full
+// SearchableSelect (covered by its own suite); a button toggles the selection.
+vi.mock('@/components/SearchableSelect', () => ({
+  default: ({ control, name }: { control: unknown; name: string }) => {
+    const { field } = useController({ control: control as never, name });
+    return (
+      <button type="button" onClick={() => field.onChange(RECIPIENTS)}>
+        Select recipients
+      </button>
+    );
+  },
+}));
+
+vi.mock('@/actions/report', () => ({
+  getReportRecipients: vi.fn(),
+  sendReportEmail: vi.fn(),
+}));
+
+vi.mock('@/components/ui/toaster', () => ({
+  toaster: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe('EmailReport', () => {
+  const mockSendReportEmail = vi.mocked(sendReportEmail);
+  const mockFetch = vi.fn();
+  const mockOnOpenChange = vi.fn();
+
+  const interval = Interval.THIS_YEAR;
+  const formattedPeriod = '01/01/2026 - 31/12/2026';
+  const filename = 'sgr-report-01-01-2026-31-12-2026.pdf';
+
+  const setup = (props = {}) =>
+    renderWithUI(
+      <EmailReport
+        open
+        interval={interval}
+        formattedPeriod={formattedPeriod}
+        filename={filename}
+        onOpenChange={mockOnOpenChange}
+        {...props}
+      />,
+    );
+
+  const selectRecipients = (user: ReturnType<typeof setup>['user']) =>
+    user.click(screen.getByRole('button', { name: 'Select recipients' }));
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', mockFetch);
+    mockSendReportEmail.mockResolvedValue(undefined as never);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const mockPdfResponse = () =>
+    mockFetch.mockResolvedValue({
+      ok: true,
+      arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(8)),
+    });
+
+  test('renders the dialog when open', async () => {
+    setup();
+
+    expect(
+      await screen.findByText('Email Analytics Report'),
+    ).toBeInTheDocument();
+  });
+
+  test('keeps the dialog closed when not open', () => {
+    setup({ open: false });
+
+    expect(screen.queryByText('Email Analytics Report')).not.toBeInTheDocument();
+  });
+
+  test('disables the submit button until recipients are selected', async () => {
+    const { user } = setup();
+
+    const submit = await screen.findByRole('button', {
+      name: /Generate & Email/i,
+    });
+    expect(submit).toBeDisabled();
+
+    await selectRecipients(user);
+
+    await waitFor(() => expect(submit).toBeEnabled());
+  });
+
+  test('generates the report and emails it to the selected recipients', async () => {
+    mockPdfResponse();
+
+    const { user } = setup();
+
+    await selectRecipients(user);
+    await user.click(
+      await screen.findByRole('button', { name: /Generate & Email/i }),
+    );
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith('/api/reports/dashboard', {
+        method: 'POST',
+        body: JSON.stringify({ period: formattedPeriod, filename }),
+      });
+    });
+
+    await waitFor(() => {
+      expect(mockSendReportEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: RECIPIENTS,
+          subject: 'Analytics Overview Report',
+          attachments: [
+            expect.objectContaining({
+              filename,
+              content: expect.any(String),
+            }),
+          ],
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(toaster.success).toHaveBeenCalledWith(
+        expect.objectContaining({ title: 'Email sent' }),
+      );
+    });
+    expect(mockOnOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  test('shows an error toast when report generation fails', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      json: vi.fn().mockResolvedValue({ error: 'Something went wrong' }),
+    });
+
+    const { user } = setup();
+
+    await selectRecipients(user);
+    await user.click(
+      await screen.findByRole('button', { name: /Generate & Email/i }),
+    );
+
+    await waitFor(() => {
+      expect(toaster.error).toHaveBeenCalledWith({
+        title: 'Download failed',
+        description: 'Something went wrong',
+      });
+    });
+
+    expect(mockSendReportEmail).not.toHaveBeenCalled();
+    expect(mockOnOpenChange).not.toHaveBeenCalled();
+  });
+
+  test('shows an error toast when sending the email fails', async () => {
+    mockPdfResponse();
+    mockSendReportEmail.mockRejectedValue(new Error('boom'));
+
+    const { user } = setup();
+
+    await selectRecipients(user);
+    await user.click(
+      await screen.findByRole('button', { name: /Generate & Email/i }),
+    );
+
+    await waitFor(() => {
+      expect(toaster.error).toHaveBeenCalledWith({
+        title: 'Email failed',
+        description: 'Failed to send the report via email.',
+      });
+    });
+
+    expect(toaster.success).not.toHaveBeenCalled();
+    expect(mockOnOpenChange).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/(protected)/(overview)/dashboard/_components/EmailReport.test.tsx
+++ b/src/app/(protected)/(overview)/dashboard/_components/EmailReport.test.tsx
@@ -87,7 +87,9 @@ describe('EmailReport', () => {
   test('keeps the dialog closed when not open', () => {
     setup({ open: false });
 
-    expect(screen.queryByText('Email Analytics Report')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Email Analytics Report'),
+    ).not.toBeInTheDocument();
   });
 
   test('disables the submit button until recipients are selected', async () => {
@@ -179,10 +181,12 @@ describe('EmailReport', () => {
     );
 
     await waitFor(() => {
-      expect(toaster.error).toHaveBeenCalledWith({
-        title: 'Email failed',
-        description: 'Failed to send the report via email.',
-      });
+      expect(toaster.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Email failed',
+          description: 'boom',
+        }),
+      );
     });
 
     expect(toaster.success).not.toHaveBeenCalled();

--- a/src/app/(protected)/(overview)/dashboard/_components/EmailReport.tsx
+++ b/src/app/(protected)/(overview)/dashboard/_components/EmailReport.tsx
@@ -1,0 +1,161 @@
+'use client';
+
+import {
+  Button,
+  CloseButton,
+  Dialog,
+  HStack,
+  Portal,
+  Span,
+} from '@chakra-ui/react';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { capitalize } from 'es-toolkit/string';
+import { useState } from 'react';
+import { useForm, useWatch } from 'react-hook-form';
+
+import SearchableSelect from '@/components/SearchableSelect';
+import { toaster } from '@/components/ui/toaster';
+
+import { formatValueUnit } from '@/utils/formatter';
+
+import { getReportRecipients, sendReportEmail } from '@/actions/report';
+import { EmailReportSchema, EmailReportSchemaValues } from '@/schemas/report';
+
+import AnalyticsReport from '../../reports/_components/AnalyticsReport';
+
+interface EmailReportProps {
+  open: boolean;
+  interval: string;
+  formattedPeriod: string;
+  filename: string;
+  onOpenChange: (open: boolean) => void;
+}
+
+export default function EmailReport({
+  interval,
+  open,
+  formattedPeriod,
+  filename,
+  onOpenChange,
+}: EmailReportProps) {
+  const [sending, setSending] = useState(false);
+
+  const { control, reset, handleSubmit } = useForm<EmailReportSchemaValues>({
+    resolver: zodResolver(EmailReportSchema),
+    defaultValues: { recipients: [] },
+  });
+
+  const recipients = useWatch({ control, name: 'recipients' });
+  const noRecipients = recipients.length === 0;
+
+  const onSubmit = async ({ recipients }: EmailReportSchemaValues) => {
+    setSending(true);
+
+    try {
+      const response = await fetch('/api/reports/dashboard', {
+        method: 'POST',
+        body: JSON.stringify({ period: formattedPeriod, filename }),
+      });
+
+      if (!response.ok) {
+        const { error } = await response.json();
+        toaster.error({
+          title: 'Download failed',
+          description: error,
+        });
+        return;
+      }
+
+      const pdfBuffer = Buffer.from(await response.arrayBuffer());
+
+      await sendReportEmail({
+        to: recipients,
+        subject: 'Analytics Overview Report',
+        html: AnalyticsReport({
+          period: formattedPeriod,
+        }),
+        attachments: [
+          {
+            content: pdfBuffer.toString('base64'),
+            filename,
+          },
+        ],
+      });
+
+      toaster.success({
+        title: 'Email sent',
+        description: `Report emailed to ${recipients.length} ${formatValueUnit(
+          recipients.length,
+          'recipient',
+        )}.`,
+      });
+
+      reset();
+      onOpenChange(false);
+    } catch (error) {
+      toaster.error({
+        title: 'Email failed',
+        description: 'Failed to send the report via email.',
+      });
+    } finally {
+      setSending(false);
+    }
+  };
+
+  return (
+    <Dialog.Root
+      open={open}
+      onOpenChange={({ open }) => onOpenChange(open)}
+      onExitComplete={() => reset()}
+    >
+      <Portal>
+        <Dialog.Backdrop />
+        <Dialog.Positioner as="form" onSubmit={handleSubmit(onSubmit)}>
+          <Dialog.Content>
+            <Dialog.Header>
+              <Dialog.Title>Email Analytics Report</Dialog.Title>
+            </Dialog.Header>
+            <Dialog.Body>
+              <SearchableSelect
+                controlledMode
+                multiple
+                name="recipients"
+                label="recipients"
+                control={control}
+                action={getReportRecipients}
+                itemToValue={({ email }) => email}
+                itemToString={({ name }) => name}
+                renderItem={({ name, email }) => (
+                  <HStack>
+                    {name}{' '}
+                    <Span fontSize="sm" color="GrayText">
+                      &lt;{email}&gt;
+                    </Span>
+                  </HStack>
+                )}
+                fieldProps={{
+                  helperText: noRecipients
+                    ? 'No recipients selected. Please select at least one.'
+                    : `${capitalize(interval.split('_').join(' '))}'s report will be emailed to ${recipients.length} ${formatValueUnit(recipients.length, 'recipient')}.`,
+                }}
+              />
+            </Dialog.Body>
+            <Dialog.Footer>
+              <Button
+                type="submit"
+                disabled={sending || recipients.length === 0}
+                loading={sending}
+                loadingText="Sending..."
+              >
+                Generate &amp; Email
+              </Button>
+            </Dialog.Footer>
+            <Dialog.CloseTrigger asChild>
+              <CloseButton size="sm" />
+            </Dialog.CloseTrigger>
+          </Dialog.Content>
+        </Dialog.Positioner>
+      </Portal>
+    </Dialog.Root>
+  );
+}

--- a/src/app/(protected)/(overview)/dashboard/_components/EmailReport.tsx
+++ b/src/app/(protected)/(overview)/dashboard/_components/EmailReport.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useState } from 'react';
+
 import {
   Button,
   CloseButton,
@@ -10,7 +12,7 @@ import {
 } from '@chakra-ui/react';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { capitalize } from 'es-toolkit/string';
-import { useState } from 'react';
+import { Base64 } from 'js-base64';
 import { useForm, useWatch } from 'react-hook-form';
 
 import SearchableSelect from '@/components/SearchableSelect';
@@ -66,7 +68,9 @@ export default function EmailReport({
         return;
       }
 
-      const pdfBuffer = Buffer.from(await response.arrayBuffer());
+      const content = Base64.fromUint8Array(
+        new Uint8Array(await response.arrayBuffer()),
+      );
 
       await sendReportEmail({
         to: recipients,
@@ -76,7 +80,7 @@ export default function EmailReport({
         }),
         attachments: [
           {
-            content: pdfBuffer.toString('base64'),
+            content,
             filename,
           },
         ],
@@ -95,7 +99,9 @@ export default function EmailReport({
     } catch (error) {
       toaster.error({
         title: 'Email failed',
-        description: 'Failed to send the report via email.',
+        duration: 10000,
+        description:
+          error instanceof Error ? error.message : 'An unknown error occurred.',
       });
     } finally {
       setSending(false);

--- a/src/app/(protected)/(overview)/reports/_components/AnalyticsReport.tsx
+++ b/src/app/(protected)/(overview)/reports/_components/AnalyticsReport.tsx
@@ -1,0 +1,14 @@
+import EmailLayout from '@/components/common/EmailLayout';
+
+interface ReportReadyProps {
+  period: string;
+}
+
+export default function AnalyticsReport({ period }: ReportReadyProps): string {
+  return EmailLayout(`
+    <p style="font-size: 14px; margin-bottom: 8px;">
+      Here is the analytics overview report for the duration: <strong>${period}</strong>.
+    </p>
+    <p style="font-size: 14px;">Click the attachment link to open or download it.</p>
+  `);
+}

--- a/src/app/(protected)/(overview)/team-rule/page.tsx
+++ b/src/app/(protected)/(overview)/team-rule/page.tsx
@@ -1,5 +1,7 @@
 import { Metadata } from 'next';
 
+import { Stack } from '@chakra-ui/react';
+
 import { getRule } from '@/actions/rule';
 
 import RuleEditor from './_components/RuleEditor';
@@ -12,5 +14,9 @@ export const metadata: Metadata = {
 export default async function TeamRulePage() {
   const rule = await getRule();
 
-  return <RuleEditor rule={rule} />;
+  return (
+    <Stack gap={10}>
+      <RuleEditor rule={rule} />
+    </Stack>
+  );
 }

--- a/src/app/(protected)/(resources)/emails/_components/EmailPreview.tsx
+++ b/src/app/(protected)/(resources)/emails/_components/EmailPreview.tsx
@@ -1,0 +1,44 @@
+import { Accordion, Span } from '@chakra-ui/react';
+import { FileChartLine, RotateCcwKey } from 'lucide-react';
+
+import ResetPassword from '@/app/(auth)/_components/ResetPassword';
+import AnalyticsReport from '@/app/(protected)/(overview)/reports/_components/AnalyticsReport';
+
+const SAMPLES: Array<{ label: string; icon: React.ReactNode; html: string }> = [
+  {
+    label: 'Reset password',
+    icon: <RotateCcwKey size={18} />,
+    html: ResetPassword({
+      name: 'Admin',
+      url: 'https://sgr-portal.vercel.app/reset-password?token=sample',
+    }),
+  },
+  {
+    label: 'Analytics Report',
+    icon: <FileChartLine size={18} />,
+    html: AnalyticsReport({
+      period: '01/01/2026 - 31/12/2026',
+    }),
+  },
+];
+
+export default function EmailPreview() {
+  return (
+    <Accordion.Root collapsible>
+      {SAMPLES.map((item, index) => (
+        <Accordion.Item key={index} value={item.label}>
+          <Accordion.ItemTrigger fontWeight="normal" fontSize="sm">
+            {item.icon}
+            <Span flex={1}>{item.label}</Span>
+            <Accordion.ItemIndicator />
+          </Accordion.ItemTrigger>
+          <Accordion.ItemContent>
+            <Accordion.ItemBody
+              dangerouslySetInnerHTML={{ __html: item.html }}
+            />
+          </Accordion.ItemContent>
+        </Accordion.Item>
+      ))}
+    </Accordion.Root>
+  );
+}

--- a/src/app/(protected)/(resources)/emails/_components/SentEmails.tsx
+++ b/src/app/(protected)/(resources)/emails/_components/SentEmails.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import { Badge, Table } from '@chakra-ui/react';
+import { useCallback } from 'react';
+import type { ListEmail } from 'resend';
+
+import Filters from '@/components/filters/Filters';
+import HighlightText from '@/components/HighlightText';
+import Pagination from '@/components/Pagination';
+import { EmptyState } from '@/components/ui/empty-state';
+
+import useTableState from '@/hooks/use-table-state';
+import { useEmailFilters } from '@/lib/nuqs';
+import type { FilterDef } from '@/types/filters';
+import { EMAIL_STATUS_SELECTION } from '@/utils/constant';
+import { formatDatetime } from '@/utils/formatter';
+import { getColor } from '@/utils/helper';
+
+const HEADERS = ['To', 'Subject', 'Status', 'Created At'] as const;
+
+const FILTERS: Array<FilterDef> = [
+  {
+    key: 'status',
+    label: 'Status',
+    control: { type: 'checkbox-group', options: EMAIL_STATUS_SELECTION },
+  },
+];
+
+export default function SentEmails({ emails }: { emails: Array<ListEmail> }) {
+  const [values, setSearchParams] = useEmailFilters();
+  const { page, q, status } = values;
+
+  const predicate = useCallback(
+    (item: ListEmail) => {
+      const matchesQuery =
+        item.to.includes(q) ||
+        item.subject.toLowerCase().includes(q.toLowerCase());
+      const matchesStatus =
+        status.length === 0 ||
+        (status as Array<string>).includes(item.last_event);
+      return matchesQuery && matchesStatus;
+    },
+    [q, status],
+  );
+
+  const { currentData, totalCount, columnCount } = useTableState(
+    emails,
+    predicate,
+    page,
+    {
+      headerCount: HEADERS.length,
+    },
+  );
+
+  return (
+    <>
+      <Filters
+        filters={FILTERS}
+        values={values}
+        defaults={useEmailFilters.defaults}
+        onApply={(next) => setSearchParams({ ...next, page: 1 })}
+      />
+      <Table.ScrollArea>
+        <Table.Root borderWidth={1} size={{ base: 'sm', md: 'md' }}>
+          <Table.Header>
+            <Table.Row>
+              {HEADERS.map((header) => (
+                <Table.ColumnHeader key={header}>{header}</Table.ColumnHeader>
+              ))}
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            {currentData.length > 0 ? (
+              currentData.map((item) => (
+                <Table.Row key={item.id}>
+                  <Table.Cell>
+                    <HighlightText query={q}>{item.to}</HighlightText>
+                  </Table.Cell>
+                  <Table.Cell>
+                    <HighlightText query={q}>{item.subject}</HighlightText>
+                  </Table.Cell>
+                  <Table.Cell>
+                    <Badge
+                      variant="surface"
+                      borderRadius="full"
+                      colorPalette={getColor(item.last_event)}
+                    >
+                      {item.last_event}
+                    </Badge>
+                  </Table.Cell>
+                  <Table.Cell>{formatDatetime(item.created_at)}</Table.Cell>
+                </Table.Row>
+              ))
+            ) : (
+              <Table.Row>
+                <Table.Cell colSpan={columnCount}>
+                  <EmptyState title="No emails sent." />
+                </Table.Cell>
+              </Table.Row>
+            )}
+          </Table.Body>
+        </Table.Root>
+      </Table.ScrollArea>
+
+      <Pagination
+        count={totalCount}
+        page={page}
+        onPageChange={setSearchParams}
+      />
+    </>
+  );
+}

--- a/src/app/(protected)/(resources)/emails/_components/SentEmails.tsx
+++ b/src/app/(protected)/(resources)/emails/_components/SentEmails.tsx
@@ -32,9 +32,12 @@ export default function SentEmails({ emails }: { emails: Array<ListEmail> }) {
 
   const predicate = useCallback(
     (item: ListEmail) => {
+      const qLower = q.toLowerCase();
+      const toText = Array.isArray(item.to) ? item.to.join(', ') : item.to;
+
       const matchesQuery =
-        item.to.includes(q) ||
-        item.subject.toLowerCase().includes(q.toLowerCase());
+        toText.toLowerCase().includes(qLower) ||
+        item.subject.toLowerCase().includes(qLower);
       const matchesStatus =
         status.length === 0 ||
         (status as Array<string>).includes(item.last_event);

--- a/src/app/(protected)/(resources)/emails/loading.tsx
+++ b/src/app/(protected)/(resources)/emails/loading.tsx
@@ -1,0 +1,22 @@
+import { Separator, Skeleton, SkeletonText, Stack } from '@chakra-ui/react';
+
+export default function Loading() {
+  return (
+    <Stack gap={{ base: 4, lg: 6 }}>
+      {/* Sent Emails title */}
+      <Skeleton height={9} width={48} />
+      {/* Filters bar (search + filters) */}
+      <Skeleton height={10} width="100%" />
+      {/* Table rows */}
+      <SkeletonText noOfLines={7} gap={2} height={10} />
+
+      <Separator />
+
+      {/* Email Preview title */}
+      <Skeleton height={9} width={48} />
+      {/* Accordion preview items */}
+      <Skeleton height={10} width="100%" />
+      <Skeleton height={10} width="100%" />
+    </Stack>
+  );
+}

--- a/src/app/(protected)/(resources)/emails/page.tsx
+++ b/src/app/(protected)/(resources)/emails/page.tsx
@@ -1,0 +1,34 @@
+import { Metadata } from 'next';
+
+import PageTitle from '@/components/PageTitle';
+import { resend } from '@/lib/resend';
+
+import { Separator, Text } from '@chakra-ui/react';
+import EmailPreview from './_components/EmailPreview';
+import SentEmails from './_components/SentEmails';
+
+export const metadata: Metadata = {
+  title: 'Email Preview',
+  description:
+    'Static, read-only previews of the transactional email templates.',
+};
+
+export default async function EmailPreviewPage() {
+  const { data, error } = await resend.emails.list();
+
+  return (
+    <>
+      <PageTitle title="Sent Emails" />
+      {error ? (
+        <Text color="tomato">Error: {error.message}</Text>
+      ) : (
+        <SentEmails emails={data.data} />
+      )}
+
+      <Separator />
+
+      <PageTitle title="Email Preview" />
+      <EmailPreview />
+    </>
+  );
+}

--- a/src/app/(protected)/(team-management)/registration/_components/SavedRegistrations.tsx
+++ b/src/app/(protected)/(team-management)/registration/_components/SavedRegistrations.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useState } from 'react';
 
 import { HStack, IconButton, Table } from '@chakra-ui/react';
+import { Base64 } from 'js-base64';
 import { Download, Trash2 } from 'lucide-react';
 
 import HighlightText from '@/components/HighlightText';
@@ -16,7 +17,7 @@ import useTableState from '@/hooks/use-table-state';
 import { useCommonParams } from '@/lib/nuqs';
 import { formatDatetime } from '@/utils/formatter';
 
-import { base64ToBytes, downloadPdf } from '../_helpers/pdf';
+import { downloadPdf } from '../_helpers/pdf';
 import { SavedRegistration } from '../_helpers/useSavedRegistrations';
 
 const HEADERS = ['Name', 'Players', 'Date saved', 'Actions'] as const;
@@ -47,7 +48,7 @@ export default function SavedRegistrations({
     toaster.promise(
       (async () =>
         downloadPdf(
-          base64ToBytes(item.pdfBase64),
+          Base64.toUint8Array(item.pdfBase64),
           item.filename ?? 'registration',
         ))(),
       {

--- a/src/app/(protected)/(team-management)/registration/_components/main.tsx
+++ b/src/app/(protected)/(team-management)/registration/_components/main.tsx
@@ -20,6 +20,7 @@ import {
   Text,
   Textarea,
 } from '@chakra-ui/react';
+import { Base64 } from 'js-base64';
 import { HelpCircle, Trophy, Upload, UsersRound } from 'lucide-react';
 
 import SearchableSelect from '@/components/SearchableSelect';
@@ -38,7 +39,7 @@ import { getActivePlayers } from '@/actions/user';
 
 import usePermissions from '@/hooks/use-permissions';
 import { CACHE_KEY } from '@/utils/constant';
-import { buildRegistrationPdf, bytesToBase64 } from '../_helpers/pdf';
+import { buildRegistrationPdf } from '../_helpers/pdf';
 import { useSavedRegistrations } from '../_helpers/useSavedRegistrations';
 
 import PreviewPanel from './PreviewPanel';
@@ -100,7 +101,7 @@ export default function RegistrationPageClient() {
         notes: notes || undefined,
         templateName: template?.name,
         filename: `saigon-rovers-${name.toLowerCase().replace(/\s+/g, '-')}`,
-        pdfBase64: bytesToBase64(bytes),
+        pdfBase64: Base64.fromUint8Array(bytes),
       });
       toaster.success({
         title: 'Registration saved',

--- a/src/app/(protected)/(team-management)/registration/_helpers/pdf.ts
+++ b/src/app/(protected)/(team-management)/registration/_helpers/pdf.ts
@@ -310,22 +310,6 @@ export const buildRosterCsv = (players: Array<User>): string =>
     }),
   ].join('\n');
 
-export const bytesToBase64 = (bytes: Uint8Array): string => {
-  let binary = '';
-  const chunk = 0x8000;
-  for (let i = 0; i < bytes.length; i += chunk) {
-    binary += String.fromCharCode(...bytes.subarray(i, i + chunk));
-  }
-  return btoa(binary);
-};
-
-export const base64ToBytes = (base64: string): Uint8Array => {
-  const binary = atob(base64);
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
-  return bytes;
-};
-
 export const downloadPdf = (bytes: Uint8Array, filename: string) =>
   triggerDownload(
     new Blob([bytes as BlobPart], { type: 'application/pdf' }),

--- a/src/app/(protected)/_helpers/utils.ts
+++ b/src/app/(protected)/_helpers/utils.ts
@@ -1,13 +1,14 @@
 import {
   BadgeCheck,
   Dumbbell,
-  FileChartColumnIncreasing,
   FileText,
   Film,
   GamepadDirectional,
   LayoutDashboard,
+  MailSearch,
   MapPinHouse,
   Package,
+  PersonStanding,
   ShieldCheck,
   Trophy,
   UsersRound,
@@ -44,13 +45,14 @@ export const SIDEBAR_GROUP: Array<SidebarGroup> = [
   },
   {
     title: 'Performance',
-    items: [{ icon: FileChartColumnIncreasing, resource: 'periodic-testing' }],
+    items: [{ icon: PersonStanding, resource: 'periodic-testing' }],
   },
   {
     title: 'Resources',
     items: [
       { icon: Package, resource: 'assets' },
       { icon: Film, resource: 'documents', disabled: true },
+      { icon: MailSearch, resource: 'emails' },
     ],
   },
   {

--- a/src/app/api/reports/dashboard/route.ts
+++ b/src/app/api/reports/dashboard/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-import { formatDate, TIME_DURATION } from '@/utils/formatter';
 import env from '@env';
 
 import { verifySession } from '@/actions/auth';
@@ -22,10 +21,9 @@ export async function POST(req: NextRequest) {
   }
 
   try {
-    const { interval, filename } = await req.json();
-    const period = TIME_DURATION[interval];
+    const { period, filename } = await req.json();
 
-    const durationLabel = `Duration: ${formatDate(period.start)} - ${formatDate(period.end)}`;
+    const durationLabel = `Duration: ${period}`;
     const generatedOn = `Generated on ${new Date().toLocaleString('en-US', {
       dateStyle: 'long',
       timeStyle: 'short',

--- a/src/components/HighlightText.tsx
+++ b/src/components/HighlightText.tsx
@@ -1,6 +1,14 @@
 import { Highlight, HighlightProps } from '@chakra-ui/react';
 
-export default function HighlightText({ query, ...props }: HighlightProps) {
+interface HighlightTextProps extends Omit<HighlightProps, 'children'> {
+  children: string | Array<string>;
+}
+
+export default function HighlightText({
+  query,
+  children,
+  ...props
+}: HighlightTextProps) {
   return (
     <Highlight
       ignoreCase
@@ -8,7 +16,7 @@ export default function HighlightText({ query, ...props }: HighlightProps) {
       styles={{ backgroundColor: 'yellow' }}
       {...props}
     >
-      {props.children}
+      {Array.isArray(children) ? children.join(', ') : children}
     </Highlight>
   );
 }

--- a/src/components/common/EmailLayout.tsx
+++ b/src/components/common/EmailLayout.tsx
@@ -1,14 +1,14 @@
-const YEAR = new Date().getFullYear();
-
 /**
  * Shared wrapper for transactional emails: logo header, divider, body slot
  * and footer. Pass the section-specific markup as `children`.
  */
 export default function EmailLayout(children: string): string {
+  const year = new Date().getFullYear();
+
   return `
   <div style="max-width: 560px; margin: 0 auto; padding: 24px; border: 1px solid #e2e8f0; border-radius: 6px;">
     <div style="margin-bottom: 16px">
-      <img src="https://sgr-portal.vercel.app/logo.png" alt="Saigon Rovers Basketball Club" width="64" height="64" style="display: block; width: 64px; height: 64px;" />
+      <img src="https://sgr-portal.vercel.app/logo.svg" alt="Saigon Rovers Basketball Club" />
     </div>
 
     <hr style="border: none; border-top: 0.5px solid #e2e8f0; margin: 0" />
@@ -18,7 +18,7 @@ export default function EmailLayout(children: string): string {
     </div>
 
     <div style="color: #718096; font-size: 12px; text-align: center;">
-      <p>© ${YEAR} Saigon Rovers Basketball Club</p>
+      <p>© ${year} Saigon Rovers Basketball Club</p>
     </div>
   </div>`;
 }

--- a/src/components/common/EmailLayout.tsx
+++ b/src/components/common/EmailLayout.tsx
@@ -1,0 +1,24 @@
+const YEAR = new Date().getFullYear();
+
+/**
+ * Shared wrapper for transactional emails: logo header, divider, body slot
+ * and footer. Pass the section-specific markup as `children`.
+ */
+export default function EmailLayout(children: string): string {
+  return `
+  <div style="max-width: 560px; margin: 0 auto; padding: 24px; border: 1px solid #e2e8f0; border-radius: 6px;">
+    <div style="margin-bottom: 16px">
+      <img src="https://sgr-portal.vercel.app/logo.png" alt="Saigon Rovers Basketball Club" width="64" height="64" style="display: block; width: 64px; height: 64px;" />
+    </div>
+
+    <hr style="border: none; border-top: 0.5px solid #e2e8f0; margin: 0" />
+
+    <div style="margin-top: 16px; margin-bottom: 32px">
+      ${children}
+    </div>
+
+    <div style="color: #718096; font-size: 12px; text-align: center;">
+      <p>© ${YEAR} Saigon Rovers Basketball Club</p>
+    </div>
+  </div>`;
+}

--- a/src/db/report.test.ts
+++ b/src/db/report.test.ts
@@ -1,0 +1,166 @@
+import { and, eq, inArray, ne, or } from 'drizzle-orm';
+
+import db from '@/drizzle';
+import { PlayerTable, UserTable } from '@/drizzle/schema';
+
+import { UserRole } from '@/utils/enum';
+
+import { MOCK_TEAM } from '@/test/mocks/team';
+import { MOCK_USER } from '@/test/mocks/user';
+
+import { fetchDefaultRecipientEmails, fetchReportRecipients } from './report';
+
+vi.mock('@/drizzle', () => ({
+  default: {
+    query: {
+      UserTable: {
+        findMany: vi.fn(),
+      },
+    },
+    selectDistinct: vi.fn(),
+  },
+}));
+
+vi.mock('@/drizzle/schema', () => ({
+  UserTable: {
+    id: 'id',
+    name: 'name',
+    email: 'email',
+    role: 'role',
+    team_id: 'team_id',
+  },
+  PlayerTable: {
+    id: 'player_id',
+    is_captain: 'is_captain',
+  },
+}));
+
+const DEFAULT_REPORT_ROLES = [UserRole.COACH, UserRole.SUPER_ADMIN];
+
+const MOCK_RECIPIENTS = [
+  {
+    ...MOCK_USER,
+    id: 'user-1',
+    email: 'coach@example.com',
+    role: UserRole.COACH,
+  },
+  {
+    ...MOCK_USER,
+    id: 'user-2',
+    email: 'player@example.com',
+    role: UserRole.PLAYER,
+  },
+];
+
+/** Builds the selectDistinct().from().leftJoin().where() chain used in report.ts */
+function mockSelectDistinctSuccess(rows: Array<{ email: string }>) {
+  const mockWhere = vi.fn().mockResolvedValue(rows);
+  const mockLeftJoin = vi.fn().mockReturnValue({ where: mockWhere });
+  const mockFrom = vi.fn().mockReturnValue({ leftJoin: mockLeftJoin });
+
+  vi.mocked(db.selectDistinct).mockReturnValue({
+    from: mockFrom,
+  } as unknown as ReturnType<typeof db.selectDistinct>);
+
+  return { mockFrom, mockLeftJoin, mockWhere };
+}
+
+function mockSelectDistinctFailure(error: unknown) {
+  const mockWhere = vi.fn().mockRejectedValue(error);
+  const mockLeftJoin = vi.fn().mockReturnValue({ where: mockWhere });
+  const mockFrom = vi.fn().mockReturnValue({ leftJoin: mockLeftJoin });
+
+  vi.mocked(db.selectDistinct).mockReturnValue({
+    from: mockFrom,
+  } as unknown as ReturnType<typeof db.selectDistinct>);
+
+  return { mockFrom, mockLeftJoin, mockWhere };
+}
+
+describe('fetchReportRecipients', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('returns recipients when database query succeeds', async () => {
+    vi.mocked(db.query.UserTable.findMany).mockResolvedValue(MOCK_RECIPIENTS);
+
+    const result = await fetchReportRecipients(MOCK_TEAM.team_id);
+
+    expect(result).toEqual(MOCK_RECIPIENTS);
+    // Verify query construction
+    expect(db.query.UserTable.findMany).toHaveBeenCalledWith({
+      where: and(
+        eq(UserTable.team_id, MOCK_TEAM.team_id),
+        ne(UserTable.role, UserRole.SUPER_ADMIN),
+      ),
+      columns: {
+        id: true,
+        name: true,
+        email: true,
+        role: true,
+      },
+    });
+  });
+
+  test('returns empty array when database query fails', async () => {
+    vi.mocked(db.query.UserTable.findMany).mockRejectedValue(
+      new Error('Database error'),
+    );
+
+    const result = await fetchReportRecipients(MOCK_TEAM.team_id);
+
+    expect(result).toEqual([]);
+  });
+});
+
+describe('fetchDefaultRecipientEmails', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('returns distinct emails when database query succeeds', async () => {
+    const rows = [
+      { email: 'coach@example.com' },
+      { email: 'captain@example.com' },
+    ];
+    const { mockFrom, mockLeftJoin, mockWhere } =
+      mockSelectDistinctSuccess(rows);
+
+    const result = await fetchDefaultRecipientEmails(MOCK_TEAM.team_id);
+
+    expect(result).toEqual(['coach@example.com', 'captain@example.com']);
+    // Verify query construction
+    expect(db.selectDistinct).toHaveBeenCalledWith({ email: UserTable.email });
+    expect(mockFrom).toHaveBeenCalledWith(UserTable);
+    expect(mockLeftJoin).toHaveBeenCalledWith(
+      PlayerTable,
+      eq(PlayerTable.id, UserTable.id),
+    );
+    expect(mockWhere).toHaveBeenCalledWith(
+      and(
+        eq(UserTable.team_id, MOCK_TEAM.team_id),
+        or(
+          inArray(UserTable.role, DEFAULT_REPORT_ROLES),
+          eq(PlayerTable.is_captain, true),
+        ),
+      ),
+    );
+  });
+
+  test('returns empty array when no default recipients exist', async () => {
+    mockSelectDistinctSuccess([]);
+
+    const result = await fetchDefaultRecipientEmails(MOCK_TEAM.team_id);
+
+    expect(result).toEqual([]);
+  });
+
+  test('returns empty array when database query fails', async () => {
+    mockSelectDistinctFailure(new Error('Database error'));
+
+    const result = await fetchDefaultRecipientEmails(MOCK_TEAM.team_id);
+
+    expect(result).toEqual([]);
+  });
+});

--- a/src/db/report.ts
+++ b/src/db/report.ts
@@ -1,0 +1,58 @@
+import { and, eq, inArray, ne, or } from 'drizzle-orm';
+
+import db from '@/drizzle';
+import { PlayerTable, UserTable } from '@/drizzle/schema';
+
+import { UserRole } from '@/utils/enum';
+
+/** Roles that always receive scheduled reports and are not user-selectable. */
+const DEFAULT_REPORT_ROLES = [UserRole.COACH, UserRole.SUPER_ADMIN];
+
+/**
+ * @description Team members a user can pick as report recipients.
+ */
+export async function fetchReportRecipients(team_id: string) {
+  try {
+    return await db.query.UserTable.findMany({
+      where: and(
+        eq(UserTable.team_id, team_id),
+        ne(UserTable.role, UserRole.SUPER_ADMIN),
+      ),
+      columns: {
+        id: true,
+        name: true,
+        email: true,
+        role: true,
+      },
+    });
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * @description Emails that always receive a report.
+ * @default Coach, Super Admin and team captain
+ */
+export async function fetchDefaultRecipientEmails(
+  team_id: string,
+): Promise<Array<string>> {
+  try {
+    const rows = await db
+      .selectDistinct({ email: UserTable.email })
+      .from(UserTable)
+      .leftJoin(PlayerTable, eq(PlayerTable.id, UserTable.id))
+      .where(
+        and(
+          eq(UserTable.team_id, team_id),
+          or(
+            inArray(UserTable.role, DEFAULT_REPORT_ROLES),
+            eq(PlayerTable.is_captain, true),
+          ),
+        ),
+      );
+    return rows.map((row) => row.email);
+  } catch {
+    return [];
+  }
+}

--- a/src/lib/auth-client.test.ts
+++ b/src/lib/auth-client.test.ts
@@ -1,0 +1,27 @@
+import { inferAdditionalFields } from 'better-auth/client/plugins';
+import { createAuthClient } from 'better-auth/react';
+
+import authClient from './auth-client';
+
+const { client, fieldsPlugin } = vi.hoisted(() => ({
+  client: { id: 'auth-client' },
+  fieldsPlugin: { id: 'infer-additional-fields' },
+}));
+
+vi.mock('better-auth/react', () => ({
+  createAuthClient: vi.fn(() => client),
+}));
+
+vi.mock('better-auth/client/plugins', () => ({
+  inferAdditionalFields: vi.fn(() => fieldsPlugin),
+}));
+
+describe('auth-client', () => {
+  test('creates the client with the additional-fields plugin', () => {
+    expect(inferAdditionalFields).toHaveBeenCalled();
+    expect(createAuthClient).toHaveBeenCalledWith({
+      plugins: [fieldsPlugin],
+    });
+    expect(authClient).toBe(client);
+  });
+});

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -1,0 +1,85 @@
+import { sendEmail } from '@/lib/resend';
+
+import ResetPassword from '@/app/(auth)/_components/ResetPassword';
+
+import auth from './auth';
+
+vi.mock('better-auth/minimal', () => ({
+  // Return the config so we can introspect and exercise its callbacks.
+  betterAuth: vi.fn((config) => config),
+}));
+
+vi.mock('better-auth/adapters/drizzle', () => ({
+  drizzleAdapter: vi.fn(() => ({ id: 'adapter' })),
+}));
+
+vi.mock('better-auth/next-js', () => ({
+  nextCookies: vi.fn(() => ({ id: 'next-cookies' })),
+}));
+
+vi.mock('@/drizzle', () => ({ default: { id: 'db' } }));
+
+vi.mock('@/lib/resend', () => ({ sendEmail: vi.fn() }));
+
+vi.mock('@/app/(auth)/_components/ResetPassword', () => ({
+  default: vi.fn(() => '<p>reset</p>'),
+}));
+
+vi.mock('@env', () => ({
+  default: {
+    DEV_URL: 'http://localhost:3000',
+    PRODUCTION_URL: 'https://sgr-portal.vercel.app',
+  },
+}));
+
+// `betterAuth` is mocked to return the raw config; view it as such for assertions.
+const config = auth as unknown as {
+  trustedOrigins: Array<string>;
+  emailAndPassword: {
+    enabled: boolean;
+    requireEmailVerification: boolean;
+    sendResetPassword: (input: {
+      user: { email: string };
+      url: string;
+    }) => Promise<void>;
+  };
+};
+
+describe('auth config', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('trusts the dev and production origins', () => {
+    expect(config.trustedOrigins).toEqual([
+      'http://localhost:3000',
+      'https://sgr-portal.vercel.app',
+    ]);
+  });
+
+  test('enables email/password without verification', () => {
+    expect(config.emailAndPassword.enabled).toBe(true);
+    expect(config.emailAndPassword.requireEmailVerification).toBe(false);
+  });
+
+  describe('sendResetPassword', () => {
+    const URL = 'https://sgr-portal.vercel.app/reset?token=abc';
+
+    test('derives the name from the email and sends the reset email', async () => {
+      await config.emailAndPassword.sendResetPassword({
+        user: { email: 'jane.doe@example.com' },
+        url: URL,
+      });
+
+      expect(ResetPassword).toHaveBeenCalledWith({
+        name: 'jane.doe',
+        url: URL,
+      });
+      expect(sendEmail).toHaveBeenCalledWith({
+        to: 'jane.doe@example.com',
+        subject: 'Create a new password',
+        html: '<p>reset</p>',
+      });
+    });
+  });
+});

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,7 +1,6 @@
 import { drizzleAdapter } from 'better-auth/adapters/drizzle';
 import { betterAuth } from 'better-auth/minimal';
 import { nextCookies } from 'better-auth/next-js';
-import { Resend } from 'resend';
 
 import { COOKIE } from '@/utils/constant';
 import { UserRole, UserState } from '@/utils/enum';
@@ -14,10 +13,9 @@ import {
   UserTable,
   VerificationTable,
 } from '@/drizzle/schema/user';
+import { sendEmail } from '@/lib/resend';
 
 import ResetPassword from '@/app/(auth)/_components/ResetPassword';
-
-const resend = new Resend(env.RESEND_API_KEY);
 
 export default betterAuth({
   appName: 'Saigon Rovers Basketball Club Portal',
@@ -38,8 +36,7 @@ export default betterAuth({
       const email = user.email;
       const name = email.split('@')[0];
 
-      await resend.emails.send({
-        from: 'Acme <onboarding@resend.dev>',
+      await sendEmail({
         to: email,
         subject: 'Create a new password',
         html: ResetPassword({ name, url }),

--- a/src/lib/nuqs.ts
+++ b/src/lib/nuqs.ts
@@ -15,6 +15,7 @@ import {
   SELECTABLE_ASSET_CATEGORIES,
   SELECTABLE_ASSET_CONDITIONS,
   SELECTABLE_ATTENDANCE_STATUS,
+  SELECTABLE_EMAIL_STATUS,
   SELECTABLE_GAME_TYPES,
   SELECTABLE_LEAGUE_STATUS,
   SELECTABLE_MATCH_TYPES,
@@ -85,6 +86,13 @@ const dashboardSearchParams = {
   interval: parseAsStringEnum(INTERVAL_VALUES).withDefault(Interval.THIS_YEAR),
 };
 
+const emailSearchParams = {
+  ...commonParams,
+  status: parseAsArrayOf(
+    parseAsStringEnum([...SELECTABLE_EMAIL_STATUS]),
+  ).withDefault([]),
+};
+
 const trainingSearchParams = {
   ...commonParams,
   interval: parseAsStringEnum(INTERVAL_VALUES).withDefault(Interval.THIS_MONTH),
@@ -131,6 +139,7 @@ export const useTrainingFilters = createFilters(trainingSearchParams, {
 export const useDashboardFilters = createFilters(dashboardSearchParams, {
   shallow: false,
 });
+export const useEmailFilters = createFilters(emailSearchParams);
 
 /* ================== 🌩️ Server-Side Loaders 🌩️ ================== */
 

--- a/src/lib/resend.test.ts
+++ b/src/lib/resend.test.ts
@@ -59,4 +59,13 @@ describe('sendEmail', () => {
 
     await expect(sendEmail(PAYLOAD)).rejects.toThrow('network down');
   });
+
+  test('throws with the error message when Resend returns an error', async () => {
+    send.mockResolvedValue({
+      data: null,
+      error: { message: 'Invalid recipient' },
+    });
+
+    await expect(sendEmail(PAYLOAD)).rejects.toThrow('Invalid recipient');
+  });
 });

--- a/src/lib/resend.test.ts
+++ b/src/lib/resend.test.ts
@@ -1,0 +1,62 @@
+import { sendEmail } from './resend';
+
+const { send } = vi.hoisted(() => ({ send: vi.fn() }));
+
+vi.mock('resend', () => ({
+  Resend: vi.fn(function () {
+    return { emails: { send } };
+  }),
+}));
+
+vi.mock('@env', () => ({
+  default: { RESEND_API_KEY: 'test-api-key' },
+}));
+
+describe('sendEmail', () => {
+  const PAYLOAD = {
+    to: 'player@example.com',
+    subject: 'Welcome',
+    html: '<p>Hello</p>',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('sends with the shared sender and prefixed subject', async () => {
+    send.mockResolvedValue({ data: { id: 'email-id' }, error: null });
+
+    await sendEmail(PAYLOAD);
+
+    expect(send).toHaveBeenCalledWith({
+      from: 'Acme <onboarding@resend.dev>',
+      to: 'player@example.com',
+      subject: 'SGR - Welcome',
+      html: '<p>Hello</p>',
+    });
+  });
+
+  test('supports multiple recipients', async () => {
+    send.mockResolvedValue({ data: { id: 'email-id' }, error: null });
+    const recipients = ['a@example.com', 'b@example.com'];
+
+    await sendEmail({ ...PAYLOAD, to: recipients });
+
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({ to: recipients }),
+    );
+  });
+
+  test('returns the Resend response', async () => {
+    const response = { data: { id: 'email-id' }, error: null };
+    send.mockResolvedValue(response);
+
+    await expect(sendEmail(PAYLOAD)).resolves.toBe(response);
+  });
+
+  test('propagates errors from Resend', async () => {
+    send.mockRejectedValue(new Error('network down'));
+
+    await expect(sendEmail(PAYLOAD)).rejects.toThrow('network down');
+  });
+});

--- a/src/lib/resend.ts
+++ b/src/lib/resend.ts
@@ -1,0 +1,32 @@
+import { Resend } from 'resend';
+
+import env from '@env';
+
+export const resend = new Resend(env.RESEND_API_KEY);
+/** Shared sender identity for all transactional emails. */
+const EMAIL_FROM = 'Acme <onboarding@resend.dev>';
+
+export interface EmailProps {
+  to: string | Array<string>;
+  subject: string;
+  html: string;
+  attachments?: Array<{
+    content: string;
+    filename: string;
+  }>;
+}
+
+export async function sendEmail({
+  to,
+  subject,
+  html,
+  attachments,
+}: EmailProps) {
+  return await resend.emails.send({
+    from: EMAIL_FROM,
+    to,
+    subject: `SGR - ${subject}`,
+    html,
+    attachments,
+  });
+}

--- a/src/lib/resend.ts
+++ b/src/lib/resend.ts
@@ -22,11 +22,17 @@ export async function sendEmail({
   html,
   attachments,
 }: EmailProps) {
-  return await resend.emails.send({
+  const response = await resend.emails.send({
     from: EMAIL_FROM,
     to,
     subject: `SGR - ${subject}`,
     html,
     attachments,
   });
+
+  if (response.error) {
+    throw new Error(response.error.message);
+  }
+
+  return response;
 }

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -38,6 +38,7 @@ export const RESOURCES = [
   'cache-store',
   'dashboard',
   'documents',
+  'emails',
   'leagues',
   'locations',
   'matches',
@@ -45,6 +46,7 @@ export const RESOURCES = [
   'profile',
   'registration',
   'roster',
+  'reports',
   'team-rule',
   'training',
 ] as const;

--- a/src/schemas/report.ts
+++ b/src/schemas/report.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+export const EmailReportSchema = z.object({
+  recipients: z.array(z.email()),
+});
+
+export type EmailReportSchemaValues = z.infer<typeof EmailReportSchema>;

--- a/src/utils/constant.ts
+++ b/src/utils/constant.ts
@@ -4,6 +4,7 @@ import {
   AssetCondition,
   AttendanceStatus,
   CoachPosition,
+  EmailStatus,
   Interval,
   LeagueStatus,
   MatchType,
@@ -374,6 +375,36 @@ export const SESSION_STATUS_SELECTION: Selection<string> = [
   },
 ];
 export const SESSION_STATUS_VALUES = [ALL.value, ...SELECTABLE_SESSION_STATUS];
+
+export const SELECTABLE_EMAIL_STATUS = [
+  EmailStatus.BOUNCED,
+  EmailStatus.CANCELED,
+  EmailStatus.CLICKED,
+  EmailStatus.COMPLAINED,
+  EmailStatus.DELIVERED,
+  EmailStatus.DELIVERY_DELAYED,
+  EmailStatus.FAILED,
+  EmailStatus.OPENED,
+  EmailStatus.QUEUED,
+  EmailStatus.SCHEDULED,
+  EmailStatus.SENT,
+  EmailStatus.SUPPRESSED,
+] as const;
+export const EMAIL_STATUS_SELECTION: Selection<string> = [
+  { label: 'Bounced', value: EmailStatus.BOUNCED },
+  { label: 'Canceled', value: EmailStatus.CANCELED },
+  { label: 'Clicked', value: EmailStatus.CLICKED },
+  { label: 'Complained', value: EmailStatus.COMPLAINED },
+  { label: 'Delivered', value: EmailStatus.DELIVERED },
+  { label: 'Delivery Delayed', value: EmailStatus.DELIVERY_DELAYED },
+  { label: 'Failed', value: EmailStatus.FAILED },
+  { label: 'Opened', value: EmailStatus.OPENED },
+  { label: 'Queued', value: EmailStatus.QUEUED },
+  { label: 'Scheduled', value: EmailStatus.SCHEDULED },
+  { label: 'Sent', value: EmailStatus.SENT },
+  { label: 'Suppressed', value: EmailStatus.SUPPRESSED },
+];
+export const EMAIL_STATUS_VALUES = [ALL.value, ...SELECTABLE_EMAIL_STATUS];
 
 export const SELECTABLE_TEST_TYPES = [
   TestTypeUnit.METERS,

--- a/src/utils/enum.ts
+++ b/src/utils/enum.ts
@@ -85,3 +85,23 @@ export enum SessionStatus {
   COMPLETED = 'COMPLETED',
   CANCELLED = 'CANCELLED',
 }
+
+export enum ReportTrigger {
+  MANUAL = 'manual',
+  SCHEDULED = 'scheduled',
+}
+
+export enum EmailStatus {
+  BOUNCED = 'bounced',
+  CANCELED = 'canceled',
+  CLICKED = 'clicked',
+  COMPLAINED = 'complained',
+  DELIVERED = 'delivered',
+  DELIVERY_DELAYED = 'delivery_delayed',
+  FAILED = 'failed',
+  OPENED = 'opened',
+  QUEUED = 'queued',
+  SCHEDULED = 'scheduled',
+  SENT = 'sent',
+  SUPPRESSED = 'suppressed',
+}

--- a/src/utils/formatter.ts
+++ b/src/utils/formatter.ts
@@ -65,3 +65,13 @@ export const TIME_DURATION: Record<string, { start: Date; end: Date }> = {
     end: endOfYear(currentDate),
   },
 };
+
+export const formatDuration = (interval: string): string => {
+  const period = TIME_DURATION[interval];
+
+  if (!period) {
+    throw new Error(`Invalid report interval: ${interval}`);
+  }
+
+  return `${formatDate(period.start)} - ${formatDate(period.end)}`;
+};

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -5,6 +5,7 @@ import {
   AssetCategory,
   AssetCondition,
   AttendanceStatus,
+  EmailStatus,
   LeagueStatus,
   MatchStatus,
   SessionStatus,
@@ -13,10 +14,13 @@ import {
 } from './enum';
 
 const COLOR_MAP: Partial<Record<ColorPalette, Array<string>>> = {
-  blue: [UserRole.PLAYER],
+  blue: [UserRole.PLAYER, EmailStatus.SENT],
   gray: [
     AssetCategory.OTHERS,
     AssetCondition.OBSOLETE,
+    EmailStatus.CANCELED,
+    EmailStatus.QUEUED,
+    EmailStatus.SUPPRESSED,
     MatchStatus.DRAW,
     SessionStatus.COMPLETED,
     UserState.UNKNOWN,
@@ -25,6 +29,9 @@ const COLOR_MAP: Partial<Record<ColorPalette, Array<string>>> = {
     AssetCategory.EQUIPMENT,
     AssetCondition.GOOD,
     AttendanceStatus.ON_TIME,
+    EmailStatus.CLICKED,
+    EmailStatus.DELIVERED,
+    EmailStatus.OPENED,
     LeagueStatus.ONGOING,
     MatchStatus.WIN,
     SessionStatus.ACTIVE,
@@ -34,6 +41,8 @@ const COLOR_MAP: Partial<Record<ColorPalette, Array<string>>> = {
     AssetCategory.TRAINING,
     AssetCondition.FAIR,
     AttendanceStatus.LATE,
+    EmailStatus.DELIVERY_DELAYED,
+    EmailStatus.SCHEDULED,
     LeagueStatus.UPCOMING,
     UserRole.SUPER_ADMIN,
     UserState.TEMPORARILY_ABSENT,
@@ -43,6 +52,9 @@ const COLOR_MAP: Partial<Record<ColorPalette, Array<string>>> = {
   red: [
     AssetCondition.POOR,
     AttendanceStatus.ABSENT,
+    EmailStatus.BOUNCED,
+    EmailStatus.COMPLAINED,
+    EmailStatus.FAILED,
     LeagueStatus.ENDED,
     MatchStatus.LOSS,
     SessionStatus.CANCELLED,

--- a/test/setup/third-parties.ts
+++ b/test/setup/third-parties.ts
@@ -24,6 +24,7 @@ vi.mock('drizzle-orm', () => ({
   gte: vi.fn((field, value) => ({ field, value, type: 'gte' })),
   lte: vi.fn((field, value) => ({ field, value, type: 'lte' })),
   ne: vi.fn((field, value) => ({ field, value, type: 'ne' })),
+  or: vi.fn((...args) => args),
   relations: vi.fn((...args) => args),
   sql: vi.fn((strings, ...values) => {
     let result = '';


### PR DESCRIPTION
#### New ✨

- Add a Resend email utility (`sendEmail`) and refactored reset-password delivery to use it.
- Implemente “Generate & Email” flow for the analytics dashboard report (PDF generation + base64 attachment emailing).
- Add a protected "/emails" resource to list sent emails (with status filters) and preview transactional email templates.

#### Bug Fixes 🐛

TODO: Gmail = strips SVG → broken logo. This is the only place that matters for the real email. - #218 

_Resolve #195_
