### PR TITLE
Introduce automatic breadcrumb navigation

### DIFF
--- a/src/app/(protected)/(performance)/periodic-testing/add-result/page.tsx
+++ b/src/app/(protected)/(performance)/periodic-testing/add-result/page.tsx
@@ -1,12 +1,7 @@
 import { Metadata } from 'next';
-import Link from 'next/link';
 import { forbidden } from 'next/navigation';
 
-import { Button, HStack } from '@chakra-ui/react';
-import { MoveLeft } from 'lucide-react';
-
 import PageTitle from '@/components/PageTitle';
-import { Tooltip } from '@/components/ui/tooltip';
 
 import { canCreateTestResult } from '@/actions/test-result';
 import AddTestResultPageClient from './_components/AddTestResultPageClient';
@@ -23,16 +18,7 @@ export default async function AddTestResultPage() {
 
   return (
     <>
-      <HStack gap={2} marginBottom={6}>
-        <Tooltip content="Back to Periodic Testing">
-          <Button variant="ghost" asChild>
-            <Link href="../periodic-testing">
-              <MoveLeft />
-            </Link>
-          </Button>
-        </Tooltip>
-        <PageTitle title="Add Test Result" />
-      </HStack>
+      <PageTitle title="Add Test Result" />
       <AddTestResultPageClient />
     </>
   );

--- a/src/app/(protected)/_components/AppHeader.tsx
+++ b/src/app/(protected)/_components/AppHeader.tsx
@@ -3,9 +3,10 @@
 import dynamic from 'next/dynamic';
 import NextImage from 'next/image';
 
-import { HStack, Image, SkeletonCircle } from '@chakra-ui/react';
+import { HStack, Image, SkeletonCircle, Stack } from '@chakra-ui/react';
 
 import HeaderLogo from '@/assets/images/header-logo.webp';
+import Breadcrumbs from './Breadcrumbs';
 
 const AccountMenu = dynamic(() => import('./AccountMenu'), {
   ssr: false,
@@ -16,17 +17,12 @@ const MobileSidebar = dynamic(() => import('./MobileSidebar'), { ssr: false });
 export default function Header() {
   return (
     <HStack
-      alignItems="center"
       paddingBlock={2}
       paddingInline={4}
-      backgroundColor="gray.50"
+      borderBottom="1px solid"
+      borderBottomColor="gray.200"
     >
-      <Image
-        width={{ base: 132, sm: 144, md: 192 }}
-        marginRight="auto"
-        alt="Text Logo"
-        asChild
-      >
+      <Image width={{ base: 132, sm: 144, md: 192 }} alt="Text Logo" asChild>
         <NextImage
           priority
           quality={100}
@@ -36,8 +32,14 @@ export default function Header() {
         />
       </Image>
 
-      <AccountMenu />
-      <MobileSidebar />
+      <Stack hideBelow="lg" marginRight="auto" marginLeft={8}>
+        <Breadcrumbs />
+      </Stack>
+
+      <HStack marginLeft="auto">
+        <AccountMenu />
+        <MobileSidebar />
+      </HStack>
     </HStack>
   );
 }

--- a/src/app/(protected)/_components/Breadcrumbs.tsx
+++ b/src/app/(protected)/_components/Breadcrumbs.tsx
@@ -6,6 +6,8 @@ import { Fragment } from 'react';
 
 import { Breadcrumb } from '@chakra-ui/react';
 
+import { segmentToLabel } from '../_helpers/utils';
+
 /**
  * Segments that have no index route of their own, so they should be rendered
  * as plain text instead of a link
@@ -13,12 +15,6 @@ import { Breadcrumb } from '@chakra-ui/react';
  * @example `/profile` only exists as `/profile/[id]`
  */
 const NON_NAVIGABLE_SEGMENTS = new Set<string>(['profile']);
-
-function toLabel(segment: string): string {
-  return segment
-    .replace(/-/g, ' ')
-    .replace(/\b\w/g, (char) => char.toUpperCase());
-}
 
 export default function Breadcrumbs() {
   const pathname = usePathname();
@@ -28,7 +24,7 @@ export default function Breadcrumbs() {
 
   const crumbs = segments.map((segment, index) => ({
     segment,
-    label: toLabel(segment),
+    label: segmentToLabel(segment),
     href: `/${segments.slice(0, index + 1).join('/')}`,
     isLast: index === segments.length - 1,
   }));

--- a/src/app/(protected)/_components/Breadcrumbs.tsx
+++ b/src/app/(protected)/_components/Breadcrumbs.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { Fragment } from 'react';
+
+import { Breadcrumb } from '@chakra-ui/react';
+
+/**
+ * Segments that have no index route of their own, so they should be rendered
+ * as plain text instead of a link
+ *
+ * @example `/profile` only exists as `/profile/[id]`
+ */
+const NON_NAVIGABLE_SEGMENTS = new Set<string>(['profile']);
+
+function toLabel(segment: string): string {
+  return segment
+    .replace(/-/g, ' ')
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+export default function Breadcrumbs() {
+  const pathname = usePathname();
+
+  const segments = pathname.split('/').filter(Boolean);
+  if (segments.length === 0) return null;
+
+  const crumbs = segments.map((segment, index) => ({
+    segment,
+    label: toLabel(segment),
+    href: `/${segments.slice(0, index + 1).join('/')}`,
+    isLast: index === segments.length - 1,
+  }));
+
+  return (
+    <Breadcrumb.Root size="md">
+      <Breadcrumb.List>
+        {crumbs.map(({ segment, label, href, isLast }) => {
+          const isLink = !isLast && !NON_NAVIGABLE_SEGMENTS.has(segment);
+
+          return (
+            <Fragment key={href}>
+              <Breadcrumb.Item>
+                {isLink ? (
+                  <Breadcrumb.Link asChild>
+                    <Link href={href}>{label}</Link>
+                  </Breadcrumb.Link>
+                ) : isLast ? (
+                  <Breadcrumb.CurrentLink>{label}</Breadcrumb.CurrentLink>
+                ) : (
+                  label
+                )}
+              </Breadcrumb.Item>
+              {!isLast && <Breadcrumb.Separator />}
+            </Fragment>
+          );
+        })}
+      </Breadcrumb.List>
+    </Breadcrumb.Root>
+  );
+}

--- a/src/app/(protected)/_components/Sidebar.tsx
+++ b/src/app/(protected)/_components/Sidebar.tsx
@@ -20,7 +20,7 @@ import { LucideProps, PanelLeftOpen, PanelRightOpen } from 'lucide-react';
 
 import { Tooltip } from '@/components/ui/tooltip';
 import usePermissions from '@/hooks/use-permissions';
-import { SIDEBAR_GROUP } from '../_helpers/utils';
+import { SIDEBAR_GROUP, segmentToLabel } from '../_helpers/utils';
 
 const BUTTON_CONFIG = {
   size: { base: 'xs', md: 'sm', mdTo2xl: 'md' },
@@ -31,12 +31,6 @@ const BUTTON_CONFIG = {
     },
   },
 } as const;
-
-function resourceToName(resource: string) {
-  return resource
-    .replace(/-/g, ' ')
-    .replace(/\b\w/g, (char) => char.toUpperCase());
-}
 
 function LoadingIndicator() {
   const { pending } = useLinkStatus();
@@ -145,7 +139,7 @@ export default function Sidebar({
               disabled={disabled}
               isExpanded={isExpanded}
             >
-              {resourceToName(resource)}
+              {segmentToLabel(resource)}
             </NavButton>
           ))}
         </VStack>

--- a/src/app/(protected)/_helpers/utils.ts
+++ b/src/app/(protected)/_helpers/utils.ts
@@ -25,6 +25,15 @@ type SidebarGroup = {
   }>;
 };
 
+/**
+ * Convert a kebab-case URL segment or resource key into a Title Case label
+ */
+export function segmentToLabel(segment: string): string {
+  return segment
+    .replace(/-/g, ' ')
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
 export const SIDEBAR_GROUP: Array<SidebarGroup> = [
   {
     title: 'Overview',

--- a/src/app/(protected)/layout.tsx
+++ b/src/app/(protected)/layout.tsx
@@ -3,7 +3,7 @@
 import { useRouter } from 'next/navigation';
 import { PropsWithChildren, Suspense, useEffect, useState } from 'react';
 
-import { Grid, GridItem, Separator, Stack } from '@chakra-ui/react';
+import { Grid, GridItem, Stack } from '@chakra-ui/react';
 
 import { toaster } from '@/components/ui/toaster';
 
@@ -11,6 +11,7 @@ import authClient from '@/lib/auth-client';
 import { LOGIN_PATH } from '@/routes';
 
 import Header from './_components/AppHeader';
+import Breadcrumbs from './_components/Breadcrumbs';
 import Sidebar from './_components/Sidebar';
 
 export default function AuthenticatedLayout({ children }: PropsWithChildren) {
@@ -53,7 +54,6 @@ export default function AuthenticatedLayout({ children }: PropsWithChildren) {
     >
       <GridItem gridArea="header">
         <Header />
-        <Separator />
       </GridItem>
 
       <GridItem
@@ -72,6 +72,13 @@ export default function AuthenticatedLayout({ children }: PropsWithChildren) {
 
       <GridItem gridArea="main" overflow="auto" height="100%">
         <Suspense>
+          <Stack
+            hideFrom="lg"
+            paddingBlock={2}
+            paddingInline={{ base: 4, lg: 6 }}
+          >
+            <Breadcrumbs />
+          </Stack>
           <Stack gap={{ base: 4, lg: 6 }} padding={{ base: 4, lg: 6 }}>
             {children}
           </Stack>


### PR DESCRIPTION
#### New ✨

- Add a new client-side Breadcrumbs component that derives crumb labels/links from `usePathname()`.
- Render breadcrumbs responsively: in the header on desktop and above the content on mobile.

#### Improvements 🙌

- Remove the manual “Back to Periodic Testing” button on the periodic testing “Add Result” page.

_Resolve #220_
