### PR TITLE
Introduce reusable DataTable component

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -132,3 +132,11 @@ Use when all 3 conditions are met:
 ## ⭐️ Others
 
 - Check the [snippet directory](https://github.com/chakra-ui/chakra-ui/tree/main/apps/compositions/src/ui) to see Chakra UI changes.
+
+### Badge Variants
+
+Pick by what the value _means_, not by the column:
+
+- `surface` + `colorPalette={getColor(...)}` → **semantic status** where the color carries meaning (status/state/condition/result). _e.g._, attendance status, asset condition, match result.
+- `outline`, no `colorPalette` → **neutral labels** that classify but aren't good/bad (role, position).
+- `surface` + fixed color → **UI accents** not driven by data (_e.g._, "TODAY", "N selected").

--- a/src/app/(protected)/(performance)/periodic-testing/_components/PlayerPerformanceMatrix.tsx
+++ b/src/app/(protected)/(performance)/periodic-testing/_components/PlayerPerformanceMatrix.tsx
@@ -19,7 +19,7 @@ import {
   updateTestResultById,
 } from '@/actions/test-result';
 import { PlayerTestResult, TestResult } from '@/types/periodic-testing';
-import { usePeriodicTestingFilters } from '@/utils/filters';
+import { usePeriodicTestingFilters } from '@/lib/nuqs';
 
 const PAGE_SIZE = 10;
 

--- a/src/app/(protected)/(performance)/periodic-testing/_components/TestingFilters.tsx
+++ b/src/app/(protected)/(performance)/periodic-testing/_components/TestingFilters.tsx
@@ -7,7 +7,7 @@ import { CalendarSearch } from 'lucide-react';
 
 import Filters from '@/components/filters/Filters';
 
-import { usePeriodicTestingFilters } from '@/utils/filters';
+import { usePeriodicTestingFilters } from '@/lib/nuqs';
 import { formatDate } from '@/utils/formatter';
 
 export default function TestingFilters({ dates }: { dates: Array<string> }) {

--- a/src/app/(protected)/(performance)/periodic-testing/_components/TestingHeader.tsx
+++ b/src/app/(protected)/(performance)/periodic-testing/_components/TestingHeader.tsx
@@ -11,7 +11,7 @@ export default function TestingHeader() {
     <HStack>
       <PageTitle title="Periodic Testing" />
       <Authorized resource="periodic-testing" action="create">
-        <HStack marginLeft="auto">
+        <HStack marginLeft="auto" gap={{ base: 3, lg: 4 }}>
           <Button size={{ base: 'sm', md: 'md' }} variant="surface" asChild>
             <Link href="/periodic-testing/test-types">
               <Settings2 size={14} />

--- a/src/app/(protected)/(performance)/periodic-testing/add-result/_components/TestResultTable.tsx
+++ b/src/app/(protected)/(performance)/periodic-testing/add-result/_components/TestResultTable.tsx
@@ -13,7 +13,8 @@ import {
 } from '@/components/ui/number-input';
 import { Tooltip } from '@/components/ui/tooltip';
 
-import { paginateData, useCommonParams } from '@/utils/filters';
+import { useCommonParams } from '@/lib/nuqs';
+import { paginateData } from '@/utils/filters';
 
 import { TestConfigurationSelection } from '@/types/periodic-testing';
 

--- a/src/app/(protected)/(performance)/periodic-testing/page.test.tsx
+++ b/src/app/(protected)/(performance)/periodic-testing/page.test.tsx
@@ -8,7 +8,7 @@ import {
 import { renderWithUI, screen } from '@/test/utilities';
 
 import { getTestDates, getTestResult } from '@/actions/test-result';
-import { loadPeriodicTestingFilters } from '@/utils/filters';
+import { loadPeriodicTestingFilters } from '@/lib/nuqs';
 
 import PeriodicTestingPage, { metadata } from './page';
 
@@ -17,7 +17,8 @@ vi.mock('@/actions/test-result', () => ({
   getTestDates: vi.fn(),
 }));
 
-vi.mock('@/utils/filters', () => ({
+vi.mock('@/lib/nuqs', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/nuqs')>()),
   loadPeriodicTestingFilters: vi.fn(),
 }));
 

--- a/src/app/(protected)/(performance)/periodic-testing/page.tsx
+++ b/src/app/(protected)/(performance)/periodic-testing/page.tsx
@@ -1,7 +1,7 @@
 import { Metadata } from 'next';
 
 import { getTestDates, getTestResult } from '@/actions/test-result';
-import { loadPeriodicTestingFilters } from '@/utils/filters';
+import { loadPeriodicTestingFilters } from '@/lib/nuqs';
 
 import PlayerPerformanceMatrix from './_components/PlayerPerformanceMatrix';
 import TestingFilters from './_components/TestingFilters';

--- a/src/app/(protected)/(performance)/periodic-testing/test-types/_components/TestTypesTable.tsx
+++ b/src/app/(protected)/(performance)/periodic-testing/test-types/_components/TestTypesTable.tsx
@@ -1,22 +1,18 @@
 'use client';
 
-import { useCallback } from 'react';
+import { useMemo } from 'react';
 
-import { Table } from '@chakra-ui/react';
 import { formatDistanceToNow } from 'date-fns';
 
-import Authorized from '@/components/Authorized';
+import DataTable, { type Column } from '@/components/DataTable';
 import HighlightText from '@/components/HighlightText';
-import Pagination from '@/components/Pagination';
-import SelectionActionBar from '@/components/SelectionActionBar';
-import { Checkbox } from '@/components/ui/checkbox';
-import { EmptyState } from '@/components/ui/empty-state';
 import { toaster } from '@/components/ui/toaster';
 
 import usePermissions from '@/hooks/use-permissions';
 import useTableState from '@/hooks/use-table-state';
 
 import { useTestTypeFilters } from '@/lib/nuqs';
+import { buildPredicate } from '@/utils/filters';
 import { formatDatetime } from '@/utils/formatter';
 
 import { removeTestType } from '@/actions/test-type';
@@ -24,31 +20,20 @@ import { TestType } from '@/drizzle/schema';
 
 import { UpsertTestType } from './UpsertTestType';
 
-const HEADERS = ['Name', 'Unit', 'Last Updated', ''] as const;
-
 export default function TestTypesTable({ data }: { data: Array<TestType> }) {
-  const { isGuest } = usePermissions();
+  const { can, isGuest } = usePermissions();
   const [{ q, page, unit }, setSearchParams] = useTestTypeFilters();
 
-  const predicate = useCallback(
-    (item: TestType) =>
-      item.name.toLowerCase().includes(q.toLowerCase()) &&
-      (unit.length === 0 || unit.includes(item.unit)),
+  const predicate = useMemo(
+    () =>
+      buildPredicate<TestType>({
+        search: { query: q, fields: ['name'] },
+        match: { unit },
+      }),
     [q, unit],
   );
-  const {
-    items,
-    currentData,
-    indeterminate,
-    selection,
-    setSelection,
-    hasSelection,
-    totalCount,
-    columnCount,
-    selectionCount,
-  } = useTableState(data, predicate, page, {
-    headerCount: HEADERS.length,
-  });
+  const { items, currentData, selection, setSelection, totalCount } =
+    useTableState(data, predicate, page);
 
   const removeItems = async () => {
     const results = await Promise.all(selection.map(removeTestType));
@@ -69,99 +54,47 @@ export default function TestTypesTable({ data }: { data: Array<TestType> }) {
     setSelection([]);
   };
 
+  const columns: Array<Column<TestType>> = [
+    {
+      header: 'Name',
+      cell: (item) => <HighlightText query={q}>{item.name}</HighlightText>,
+    },
+    { header: 'Unit', cell: (item) => item.unit },
+    { header: 'Last Updated', cell: (item) => formatDatetime(item.updated_at) },
+    {
+      header: '',
+      cell: (item) =>
+        formatDistanceToNow(item.updated_at, { addSuffix: true }),
+      cellProps: { color: 'GrayText' },
+    },
+  ];
+
   return (
     <>
-      <Table.ScrollArea>
-        <Table.Root
-          borderWidth={1}
-          size={{ base: 'sm', md: 'md' }}
-          interactive={totalCount > 0}
-        >
-          <Table.Header>
-            <Table.Row>
-              <Authorized resource="periodic-testing" action="delete">
-                <Table.ColumnHeader width={4}>
-                  <Checkbox
-                    top={0.5}
-                    aria-label="Select all rows"
-                    checked={
-                      indeterminate ? 'indeterminate' : selectionCount > 0
-                    }
-                    onCheckedChange={(changes) =>
-                      setSelection(
-                        changes.checked
-                          ? items.map(({ type_id }) => type_id)
-                          : [],
-                      )
-                    }
-                  />
-                </Table.ColumnHeader>
-              </Authorized>
-              {HEADERS.map((header, index) => (
-                <Table.ColumnHeader key={index}>{header}</Table.ColumnHeader>
-              ))}
-            </Table.Row>
-          </Table.Header>
-          <Table.Body>
-            {currentData.length > 0 ? (
-              currentData.map((item) => (
-                <Table.Row
-                  key={item.type_id}
-                  _hover={{ cursor: isGuest ? 'default' : 'pointer' }}
-                  onClick={() => {
-                    if (isGuest) return;
-                    UpsertTestType.open('update-test-type', {
-                      action: 'Update',
-                      item,
-                    });
-                  }}
-                >
-                  <Authorized resource="periodic-testing" action="delete">
-                    <Table.Cell onClick={(e) => e.stopPropagation()}>
-                      <Checkbox
-                        top={0.5}
-                        aria-label="Select row"
-                        checked={selection.includes(item.type_id)}
-                        onCheckedChange={(changes) =>
-                          setSelection((prev) =>
-                            changes.checked
-                              ? [...prev, item.type_id]
-                              : selection.filter((id) => id !== item.type_id),
-                          )
-                        }
-                      />
-                    </Table.Cell>
-                  </Authorized>
-                  <Table.Cell>
-                    <HighlightText query={q}>{item.name}</HighlightText>
-                  </Table.Cell>
-                  <Table.Cell>{item.unit}</Table.Cell>
-                  <Table.Cell>{formatDatetime(item.updated_at)}</Table.Cell>
-                  <Table.Cell color="GrayText">
-                    {formatDistanceToNow(item.updated_at, { addSuffix: true })}
-                  </Table.Cell>
-                </Table.Row>
-              ))
-            ) : (
-              <Table.Row>
-                <Table.Cell colSpan={columnCount}>
-                  <EmptyState title="No matching names found" />
-                </Table.Cell>
-              </Table.Row>
-            )}
-          </Table.Body>
-        </Table.Root>
-      </Table.ScrollArea>
-
-      <Pagination
-        count={totalCount}
+      <DataTable
+        columns={columns}
+        rowId={(item) => item.type_id}
+        currentData={currentData}
+        totalCount={totalCount}
         page={page}
         onPageChange={setSearchParams}
-      />
-      <SelectionActionBar
-        open={hasSelection}
-        selectionCount={selectionCount}
-        onDelete={removeItems}
+        empty={{ title: 'No matching names found' }}
+        onRowClick={
+          isGuest
+            ? undefined
+            : (item) =>
+                UpsertTestType.open('update-test-type', {
+                  action: 'Update',
+                  item,
+                })
+        }
+        selection={{
+          canSelect: can('periodic-testing', 'delete'),
+          items,
+          selection,
+          setSelection,
+          onDelete: removeItems,
+        }}
       />
       <UpsertTestType.Viewport />
     </>

--- a/src/app/(protected)/(resources)/assets/_components/AssetTable.tsx
+++ b/src/app/(protected)/(resources)/assets/_components/AssetTable.tsx
@@ -1,22 +1,19 @@
 'use client';
 
-import { useCallback } from 'react';
+import { useMemo } from 'react';
 
-import { Badge, Table } from '@chakra-ui/react';
+import { Badge } from '@chakra-ui/react';
 import { capitalize } from 'es-toolkit/string';
 
-import Authorized from '@/components/Authorized';
+import DataTable, { type Column } from '@/components/DataTable';
 import HighlightText from '@/components/HighlightText';
-import Pagination from '@/components/Pagination';
-import SelectionActionBar from '@/components/SelectionActionBar';
-import { Checkbox } from '@/components/ui/checkbox';
-import { EmptyState } from '@/components/ui/empty-state';
 import { toaster } from '@/components/ui/toaster';
 
 import usePermissions from '@/hooks/use-permissions';
 import useTableState from '@/hooks/use-table-state';
 
 import { useAssetFilters } from '@/lib/nuqs';
+import { buildPredicate } from '@/utils/filters';
 import { formatDate, formatDatetime } from '@/utils/formatter';
 import { getColor } from '@/utils/helper';
 
@@ -25,41 +22,20 @@ import { Asset } from '@/drizzle/schema/asset';
 
 import { UpsertAsset } from './UpsertAsset';
 
-const HEADERS = [
-  'Name',
-  'Category',
-  'Quantity',
-  'Condition',
-  'Assigned To',
-  'Acquired Date',
-  'Last Updated',
-  'Note',
-] as const;
-
 export default function AssetTable({ data }: { data: Array<Asset> }) {
-  const { isGuest } = usePermissions();
+  const { can, isGuest } = usePermissions();
   const [{ q, page, category, condition }, setSearchParams] = useAssetFilters();
 
-  const predicate = useCallback(
-    (item: Asset) =>
-      item.name.toLowerCase().includes(q.toLowerCase()) &&
-      (category.length === 0 || category.includes(item.category)) &&
-      (condition.length === 0 || condition.includes(item.condition)),
+  const predicate = useMemo(
+    () =>
+      buildPredicate<Asset>({
+        search: { query: q, fields: ['name'] },
+        match: { category, condition },
+      }),
     [q, category, condition],
   );
-  const {
-    items,
-    currentData,
-    indeterminate,
-    selection,
-    setSelection,
-    hasSelection,
-    totalCount,
-    columnCount,
-    selectionCount,
-  } = useTableState(data, predicate, page, {
-    headerCount: HEADERS.length,
-  });
+  const { items, currentData, selection, setSelection, totalCount } =
+    useTableState(data, predicate, page);
 
   const removeItems = async () => {
     const results = await Promise.all(selection.map(removeAsset));
@@ -76,117 +52,61 @@ export default function AssetTable({ data }: { data: Array<Asset> }) {
     setSelection([]);
   };
 
+  const columns: Array<Column<Asset>> = [
+    {
+      header: 'Name',
+      cell: (item) => <HighlightText query={q}>{item.name}</HighlightText>,
+    },
+    {
+      header: 'Category',
+      cell: (item) => (
+        <Badge variant="outline" borderRadius="full">
+          {capitalize(item.category)}
+        </Badge>
+      ),
+    },
+    { header: 'Quantity', cell: (item) => item.quantity },
+    {
+      header: 'Condition',
+      cell: (item) => (
+        <Badge
+          variant="surface"
+          borderRadius="full"
+          colorPalette={getColor(item.condition)}
+        >
+          {capitalize(item.condition)}
+        </Badge>
+      ),
+    },
+    { header: 'Assigned To', cell: (item) => item.user?.name },
+    { header: 'Acquired Date', cell: (item) => formatDate(item.acquired_date) },
+    { header: 'Last Updated', cell: (item) => formatDatetime(item.updated_at) },
+    { header: 'Note', cell: (item) => item.note },
+  ];
+
   return (
     <>
-      <Table.ScrollArea>
-        <Table.Root
-          borderWidth={1}
-          size={{ base: 'sm', md: 'md' }}
-          interactive={totalCount > 0}
-        >
-          <Table.Header>
-            <Table.Row>
-              <Authorized resource="assets" action="delete">
-                <Table.ColumnHeader width={4}>
-                  <Checkbox
-                    top={0.5}
-                    aria-label="Select all rows"
-                    checked={
-                      indeterminate ? 'indeterminate' : selectionCount > 0
-                    }
-                    onCheckedChange={(changes) => {
-                      setSelection(
-                        changes.checked
-                          ? items.map(({ asset_id }) => asset_id)
-                          : [],
-                      );
-                    }}
-                  />
-                </Table.ColumnHeader>
-              </Authorized>
-              {HEADERS.map((header) => (
-                <Table.ColumnHeader key={header}>{header}</Table.ColumnHeader>
-              ))}
-            </Table.Row>
-          </Table.Header>
-          <Table.Body>
-            {currentData.length > 0 ? (
-              currentData.map((item) => (
-                <Table.Row
-                  key={item.asset_id}
-                  _hover={{ cursor: isGuest ? 'default' : 'pointer' }}
-                  onClick={() => {
-                    if (isGuest) return;
-                    UpsertAsset.open('update-asset', {
-                      action: 'Update',
-                      item,
-                    });
-                  }}
-                >
-                  <Authorized resource="assets" action="delete">
-                    <Table.Cell onClick={(e) => e.stopPropagation()}>
-                      <Checkbox
-                        top={0.5}
-                        aria-label="Select row"
-                        checked={selection.includes(item.asset_id)}
-                        onCheckedChange={(changes) => {
-                          setSelection((prev) =>
-                            changes.checked
-                              ? [...prev, item.asset_id]
-                              : selection.filter((id) => id !== item.asset_id),
-                          );
-                        }}
-                      />
-                    </Table.Cell>
-                  </Authorized>
-                  <Table.Cell>
-                    <HighlightText query={q}>{item.name}</HighlightText>
-                  </Table.Cell>
-                  <Table.Cell>
-                    <Badge
-                      variant="surface"
-                      borderRadius="full"
-                      colorPalette={getColor(item.category)}
-                    >
-                      {capitalize(item.category)}
-                    </Badge>
-                  </Table.Cell>
-                  <Table.Cell>{item.quantity}</Table.Cell>
-                  <Table.Cell>
-                    <Badge
-                      variant="outline"
-                      borderRadius="full"
-                      colorPalette={getColor(item.condition)}
-                    >
-                      {capitalize(item.condition)}
-                    </Badge>
-                  </Table.Cell>
-                  <Table.Cell>{item.user?.name || '-'}</Table.Cell>
-                  <Table.Cell>{formatDate(item.acquired_date)}</Table.Cell>
-                  <Table.Cell>{formatDatetime(item.updated_at)}</Table.Cell>
-                  <Table.Cell>{item.note}</Table.Cell>
-                </Table.Row>
-              ))
-            ) : (
-              <Table.Row>
-                <Table.Cell colSpan={columnCount}>
-                  <EmptyState title="No assets found" />
-                </Table.Cell>
-              </Table.Row>
-            )}
-          </Table.Body>
-        </Table.Root>
-      </Table.ScrollArea>
-
-      <Pagination
-        count={totalCount}
+      <DataTable
+        columns={columns}
+        rowId={(item) => item.asset_id}
+        currentData={currentData}
+        totalCount={totalCount}
         page={page}
         onPageChange={setSearchParams}
-      />
-      <SelectionActionBar
-        open={hasSelection}
-        selectionCount={selectionCount}
-        onDelete={removeItems}
+        empty={{ title: 'No assets found' }}
+        onRowClick={
+          isGuest
+            ? undefined
+            : (item) =>
+                UpsertAsset.open('update-asset', { action: 'Update', item })
+        }
+        selection={{
+          canSelect: can('assets', 'delete'),
+          items,
+          selection,
+          setSelection,
+          onDelete: removeItems,
+        }}
       />
       <UpsertAsset.Viewport />
     </>

--- a/src/app/(protected)/(resources)/emails/_components/SentEmails.tsx
+++ b/src/app/(protected)/(resources)/emails/_components/SentEmails.tsx
@@ -1,22 +1,21 @@
 'use client';
 
-import { Badge, Table } from '@chakra-ui/react';
-import { useCallback } from 'react';
+import { useMemo } from 'react';
+
+import { Badge } from '@chakra-ui/react';
 import type { ListEmail } from 'resend';
 
+import DataTable, { type Column } from '@/components/DataTable';
 import Filters from '@/components/filters/Filters';
 import HighlightText from '@/components/HighlightText';
-import Pagination from '@/components/Pagination';
-import { EmptyState } from '@/components/ui/empty-state';
 
 import useTableState from '@/hooks/use-table-state';
 import { useEmailFilters } from '@/lib/nuqs';
 import type { FilterDef } from '@/types/filters';
 import { EMAIL_STATUS_SELECTION } from '@/utils/constant';
+import { buildPredicate } from '@/utils/filters';
 import { formatDatetime } from '@/utils/formatter';
 import { getColor } from '@/utils/helper';
-
-const HEADERS = ['To', 'Subject', 'Status', 'Created At'] as const;
 
 const FILTERS: Array<FilterDef> = [
   {
@@ -30,30 +29,45 @@ export default function SentEmails({ emails }: { emails: Array<ListEmail> }) {
   const [values, setSearchParams] = useEmailFilters();
   const { page, q, status } = values;
 
-  const predicate = useCallback(
-    (item: ListEmail) => {
-      const qLower = q.toLowerCase();
-      const toText = Array.isArray(item.to) ? item.to.join(', ') : item.to;
-
-      const matchesQuery =
-        toText.toLowerCase().includes(qLower) ||
-        item.subject.toLowerCase().includes(qLower);
-      const matchesStatus =
-        status.length === 0 ||
-        (status as Array<string>).includes(item.last_event);
-      return matchesQuery && matchesStatus;
-    },
+  const predicate = useMemo(
+    () =>
+      buildPredicate<ListEmail>({
+        search: {
+          query: q,
+          fields: [
+            (item) => (Array.isArray(item.to) ? item.to.join(', ') : item.to),
+            'subject',
+          ],
+        },
+        match: { last_event: status },
+      }),
     [q, status],
   );
+  const { currentData, totalCount } = useTableState(emails, predicate, page);
 
-  const { currentData, totalCount, columnCount } = useTableState(
-    emails,
-    predicate,
-    page,
+  const columns: Array<Column<ListEmail>> = [
     {
-      headerCount: HEADERS.length,
+      header: 'To',
+      cell: (item) => <HighlightText query={q}>{item.to}</HighlightText>,
     },
-  );
+    {
+      header: 'Subject',
+      cell: (item) => <HighlightText query={q}>{item.subject}</HighlightText>,
+    },
+    {
+      header: 'Status',
+      cell: (item) => (
+        <Badge
+          variant="surface"
+          borderRadius="full"
+          colorPalette={getColor(item.last_event)}
+        >
+          {item.last_event}
+        </Badge>
+      ),
+    },
+    { header: 'Created At', cell: (item) => formatDatetime(item.created_at) },
+  ];
 
   return (
     <>
@@ -63,52 +77,14 @@ export default function SentEmails({ emails }: { emails: Array<ListEmail> }) {
         defaults={useEmailFilters.defaults}
         onApply={(next) => setSearchParams({ ...next, page: 1 })}
       />
-      <Table.ScrollArea>
-        <Table.Root borderWidth={1} size={{ base: 'sm', md: 'md' }}>
-          <Table.Header>
-            <Table.Row>
-              {HEADERS.map((header) => (
-                <Table.ColumnHeader key={header}>{header}</Table.ColumnHeader>
-              ))}
-            </Table.Row>
-          </Table.Header>
-          <Table.Body>
-            {currentData.length > 0 ? (
-              currentData.map((item) => (
-                <Table.Row key={item.id}>
-                  <Table.Cell>
-                    <HighlightText query={q}>{item.to}</HighlightText>
-                  </Table.Cell>
-                  <Table.Cell>
-                    <HighlightText query={q}>{item.subject}</HighlightText>
-                  </Table.Cell>
-                  <Table.Cell>
-                    <Badge
-                      variant="surface"
-                      borderRadius="full"
-                      colorPalette={getColor(item.last_event)}
-                    >
-                      {item.last_event}
-                    </Badge>
-                  </Table.Cell>
-                  <Table.Cell>{formatDatetime(item.created_at)}</Table.Cell>
-                </Table.Row>
-              ))
-            ) : (
-              <Table.Row>
-                <Table.Cell colSpan={columnCount}>
-                  <EmptyState title="No emails sent." />
-                </Table.Cell>
-              </Table.Row>
-            )}
-          </Table.Body>
-        </Table.Root>
-      </Table.ScrollArea>
-
-      <Pagination
-        count={totalCount}
+      <DataTable
+        columns={columns}
+        rowId={(item) => item.id}
+        currentData={currentData}
+        totalCount={totalCount}
         page={page}
         onPageChange={setSearchParams}
+        empty={{ title: 'No emails sent.' }}
       />
     </>
   );

--- a/src/app/(protected)/(settings)/leagues/_components/LeagueTable.tsx
+++ b/src/app/(protected)/(settings)/leagues/_components/LeagueTable.tsx
@@ -1,20 +1,18 @@
 'use client';
 
-import { useCallback, useTransition } from 'react';
+import { useMemo, useTransition } from 'react';
 
-import { Badge, Table } from '@chakra-ui/react';
+import { Badge } from '@chakra-ui/react';
+import { capitalize } from 'es-toolkit/string';
 import { CircuitBoard } from 'lucide-react';
 
-import Authorized from '@/components/Authorized';
+import DataTable, { type Column } from '@/components/DataTable';
 import HighlightText from '@/components/HighlightText';
-import Pagination from '@/components/Pagination';
-import SelectionActionBar from '@/components/SelectionActionBar';
-import { Checkbox } from '@/components/ui/checkbox';
-import { EmptyState } from '@/components/ui/empty-state';
 import { toaster } from '@/components/ui/toaster';
 
+import { useLeagueFilters } from '@/lib/nuqs';
 import { LeagueStatus } from '@/utils/enum';
-import { useLeagueFilters } from '@/utils/filters';
+import { buildPredicate } from '@/utils/filters';
 import { formatDate } from '@/utils/formatter';
 import { getColor } from '@/utils/helper';
 
@@ -26,14 +24,6 @@ import { League } from '@/drizzle/schema';
 
 import { UpsertLeague } from './UpsertLeague';
 
-const HEADERS = [
-  'Name',
-  'No. Players',
-  'Start Date',
-  'End Date',
-  'Status',
-] as const;
-
 type LeagueWithPlayerCount = League & { player_count: number };
 
 export default function LeagueTable({
@@ -41,34 +31,20 @@ export default function LeagueTable({
 }: {
   leagues: Array<LeagueWithPlayerCount>;
 }) {
-  const { isGuest } = usePermissions();
+  const { can, isGuest } = usePermissions();
   const [isPending, startTransition] = useTransition();
   const [{ q, page, status }, setSearchParams] = useLeagueFilters();
 
-  const predicate = useCallback(
-    (item: LeagueWithPlayerCount) =>
-      item.name.toLowerCase().includes(q.toLowerCase()) &&
-      (status.length === 0 || status.includes(item.status)),
+  const predicate = useMemo(
+    () =>
+      buildPredicate<LeagueWithPlayerCount>({
+        search: { query: q, fields: ['name'] },
+        match: { status },
+      }),
     [q, status],
   );
-  const {
-    items,
-    currentData,
-    selection,
-    setSelection,
-    hasSelection,
-    totalCount,
-    columnCount,
-    selectionCount,
-  } = useTableState(leagues, predicate, page, {
-    headerCount: HEADERS.length,
-  });
-
-  // Only Upcoming leagues can be selected
-  const isUpcoming = ({ status }: League) => status === LeagueStatus.UPCOMING;
-  const selectableItems = items.filter(isUpcoming);
-  const selectableCount = selectableItems.length;
-  const indeterminate = hasSelection && selectionCount < selectableCount;
+  const { items, currentData, selection, setSelection, totalCount } =
+    useTableState(leagues, predicate, page);
 
   const removeItems = async () => {
     const id = toaster.create({
@@ -94,111 +70,54 @@ export default function LeagueTable({
     });
   };
 
+  const columns: Array<Column<LeagueWithPlayerCount>> = [
+    {
+      header: 'Name',
+      cell: (item) => <HighlightText query={q}>{item.name}</HighlightText>,
+    },
+    { header: 'No. Players', cell: (item) => item.player_count },
+    { header: 'Start Date', cell: (item) => formatDate(item.start_date) },
+    { header: 'End Date', cell: (item) => formatDate(item.end_date) },
+    {
+      header: 'Status',
+      cell: (item) => (
+        <Badge
+          variant="surface"
+          borderRadius="full"
+          colorPalette={getColor(item.status)}
+        >
+          {capitalize(item.status)}
+        </Badge>
+      ),
+    },
+  ];
+
   return (
     <>
-      <Table.ScrollArea>
-        <Table.Root
-          borderWidth={1}
-          size={{ base: 'sm', md: 'md' }}
-          interactive={totalCount > 0}
-        >
-          <Table.Header>
-            <Table.Row>
-              <Authorized resource="leagues" action="delete">
-                <Table.ColumnHeader width={4}>
-                  <Checkbox
-                    top={0.5}
-                    aria-label="Select all rows"
-                    disabled={selectableCount === 0 || isPending}
-                    checked={
-                      indeterminate ? 'indeterminate' : selectionCount > 0
-                    }
-                    onCheckedChange={(changes) => {
-                      setSelection(
-                        changes.checked
-                          ? selectableItems.map(({ league_id }) => league_id)
-                          : [],
-                      );
-                    }}
-                  />
-                </Table.ColumnHeader>
-              </Authorized>
-              {HEADERS.map((header) => (
-                <Table.ColumnHeader key={header}>{header}</Table.ColumnHeader>
-              ))}
-            </Table.Row>
-          </Table.Header>
-          <Table.Body>
-            {currentData.length > 0 ? (
-              currentData.map((item) => (
-                <Table.Row
-                  key={item.league_id}
-                  _hover={{ cursor: isGuest ? 'default' : 'pointer' }}
-                  onClick={() => {
-                    if (isGuest) return;
-                    UpsertLeague.open('update-league', {
-                      action: 'Update',
-                      item,
-                    });
-                  }}
-                >
-                  <Authorized resource="leagues" action="delete">
-                    <Table.Cell onClick={(e) => e.stopPropagation()}>
-                      <Checkbox
-                        top={0.5}
-                        aria-label="Select row"
-                        disabled={!isUpcoming(item) || isPending}
-                        checked={selection.includes(item.league_id)}
-                        onCheckedChange={(changes) => {
-                          setSelection((prev) =>
-                            changes.checked
-                              ? [...prev, item.league_id]
-                              : prev.filter((id) => id !== item.league_id),
-                          );
-                        }}
-                      />
-                    </Table.Cell>
-                  </Authorized>
-                  <Table.Cell>
-                    <HighlightText query={q}>{item.name}</HighlightText>
-                  </Table.Cell>
-                  <Table.Cell>{item.player_count}</Table.Cell>
-                  <Table.Cell>{formatDate(item.start_date)}</Table.Cell>
-                  <Table.Cell>{formatDate(item.end_date)}</Table.Cell>
-                  <Table.Cell>
-                    <Badge
-                      variant="surface"
-                      borderRadius="full"
-                      colorPalette={getColor(item.status)}
-                    >
-                      {item.status}
-                    </Badge>
-                  </Table.Cell>
-                </Table.Row>
-              ))
-            ) : (
-              <Table.Row>
-                <Table.Cell colSpan={columnCount}>
-                  <EmptyState
-                    title="No leagues found"
-                    icon={<CircuitBoard />}
-                  />
-                </Table.Cell>
-              </Table.Row>
-            )}
-          </Table.Body>
-        </Table.Root>
-      </Table.ScrollArea>
-
-      <Pagination
-        count={totalCount}
+      <DataTable
+        columns={columns}
+        rowId={(item) => item.league_id}
+        currentData={currentData}
+        totalCount={totalCount}
         page={page}
         onPageChange={setSearchParams}
-      />
-      <SelectionActionBar
-        open={hasSelection}
-        selectionCount={selectionCount}
-        onDelete={removeItems}
+        empty={{ title: 'No leagues found', icon: <CircuitBoard /> }}
+        onRowClick={
+          isGuest
+            ? undefined
+            : (item) =>
+                UpsertLeague.open('update-league', { action: 'Update', item })
+        }
+        selection={{
+          canSelect: can('leagues', 'delete'),
+          items,
+          selection,
+          setSelection,
+          // Only Upcoming leagues can be selected
+          isSelectable: (item) => item.status === LeagueStatus.UPCOMING,
+          disabled: isPending,
+          onDelete: removeItems,
+        }}
       />
       <UpsertLeague.Viewport />
     </>

--- a/src/app/(protected)/(settings)/locations/_components/LocationTable.tsx
+++ b/src/app/(protected)/(settings)/locations/_components/LocationTable.tsx
@@ -1,22 +1,18 @@
 'use client';
 
-import { useCallback } from 'react';
+import { useMemo } from 'react';
 
-import { Table } from '@chakra-ui/react';
 import { MapPinXInside } from 'lucide-react';
 
-import Authorized from '@/components/Authorized';
 import { LocationLink } from '@/components/common/LocationSelection';
+import DataTable, { type Column } from '@/components/DataTable';
 import HighlightText from '@/components/HighlightText';
-import Pagination from '@/components/Pagination';
-import SelectionActionBar from '@/components/SelectionActionBar';
-import { Checkbox } from '@/components/ui/checkbox';
-import { EmptyState } from '@/components/ui/empty-state';
 import { toaster } from '@/components/ui/toaster';
 
 import usePermissions from '@/hooks/use-permissions';
 import useTableState from '@/hooks/use-table-state';
 import { useCommonParams } from '@/lib/nuqs';
+import { buildPredicate } from '@/utils/filters';
 import { formatDatetime } from '@/utils/formatter';
 
 import { removeLocation } from '@/actions/location';
@@ -24,39 +20,23 @@ import { Location } from '@/drizzle/schema';
 
 import { UpsertLocation } from './UpsertLocation';
 
-const HEADERS = ['Name', 'Address', 'Last Updated'] as const;
-
 export default function LocationTable({
   locations,
 }: {
   locations: Array<Location>;
 }) {
-  const { isGuest } = usePermissions();
+  const { can, isGuest } = usePermissions();
   const [{ q, page }, setSearchParams] = useCommonParams();
 
-  const predicate = useCallback(
-    (item: Location) => {
-      const query = q.toLowerCase();
-      return (
-        item.name.toLowerCase().includes(query) ||
-        item.address.toLowerCase().includes(query)
-      );
-    },
+  const predicate = useMemo(
+    () =>
+      buildPredicate<Location>({
+        search: { query: q, fields: ['name', 'address'] },
+      }),
     [q],
   );
-  const {
-    items,
-    currentData,
-    indeterminate,
-    selection,
-    setSelection,
-    hasSelection,
-    totalCount,
-    columnCount,
-    selectionCount,
-  } = useTableState(locations, predicate, page, {
-    headerCount: HEADERS.length,
-  });
+  const { items, currentData, selection, setSelection, totalCount } =
+    useTableState(locations, predicate, page);
 
   const removeItems = async () => {
     const results = await Promise.all(selection.map(removeLocation));
@@ -73,105 +53,51 @@ export default function LocationTable({
     setSelection([]);
   };
 
+  const columns: Array<Column<Location>> = [
+    {
+      header: 'Name',
+      cell: (item) => (
+        <LocationLink name={item.name}>
+          <HighlightText query={q}>{item.name}</HighlightText>
+        </LocationLink>
+      ),
+    },
+    {
+      header: 'Address',
+      cell: (item) => <HighlightText query={q}>{item.address}</HighlightText>,
+    },
+    {
+      header: 'Last Updated',
+      cell: (item) => formatDatetime(item.updated_at),
+    },
+  ];
+
   return (
     <>
-      <Table.ScrollArea>
-        <Table.Root
-          borderWidth={1}
-          size={{ base: 'sm', md: 'md' }}
-          interactive={totalCount > 0}
-        >
-          <Table.Header>
-            <Table.Row>
-              <Authorized resource="locations" action="delete">
-                <Table.ColumnHeader width={4}>
-                  <Checkbox
-                    top={0.5}
-                    aria-label="Select all rows"
-                    checked={
-                      indeterminate ? 'indeterminate' : selectionCount > 0
-                    }
-                    onCheckedChange={(changes) => {
-                      setSelection(
-                        changes.checked
-                          ? items.map(({ location_id }) => location_id)
-                          : [],
-                      );
-                    }}
-                  />
-                </Table.ColumnHeader>
-              </Authorized>
-              {HEADERS.map((header) => (
-                <Table.ColumnHeader key={header}>{header}</Table.ColumnHeader>
-              ))}
-            </Table.Row>
-          </Table.Header>
-          <Table.Body>
-            {currentData.length > 0 ? (
-              currentData.map((item) => (
-                <Table.Row
-                  key={item.location_id}
-                  _hover={{ cursor: isGuest ? 'default' : 'pointer' }}
-                  onClick={() => {
-                    if (isGuest) return;
-                    UpsertLocation.open('update-location', {
-                      action: 'Update',
-                      item,
-                    });
-                  }}
-                >
-                  <Authorized resource="locations" action="delete">
-                    <Table.Cell onClick={(e) => e.stopPropagation()}>
-                      <Checkbox
-                        top={0.5}
-                        aria-label="Select row"
-                        checked={selection.includes(item.location_id)}
-                        onCheckedChange={(changes) => {
-                          setSelection((prev) =>
-                            changes.checked
-                              ? [...prev, item.location_id]
-                              : selection.filter(
-                                  (id) => id !== item.location_id,
-                                ),
-                          );
-                        }}
-                      />
-                    </Table.Cell>
-                  </Authorized>
-                  <Table.Cell>
-                    <LocationLink name={item.name}>
-                      <HighlightText query={q}>{item.name}</HighlightText>
-                    </LocationLink>
-                  </Table.Cell>
-                  <Table.Cell>
-                    <HighlightText query={q}>{item.address}</HighlightText>
-                  </Table.Cell>
-                  <Table.Cell>{formatDatetime(item.updated_at)}</Table.Cell>
-                </Table.Row>
-              ))
-            ) : (
-              <Table.Row>
-                <Table.Cell colSpan={columnCount}>
-                  <EmptyState
-                    title="No locations found"
-                    icon={<MapPinXInside />}
-                  />
-                </Table.Cell>
-              </Table.Row>
-            )}
-          </Table.Body>
-        </Table.Root>
-      </Table.ScrollArea>
-
-      <Pagination
-        count={totalCount}
+      <DataTable
+        columns={columns}
+        rowId={(item) => item.location_id}
+        currentData={currentData}
+        totalCount={totalCount}
         page={page}
         onPageChange={setSearchParams}
-      />
-      <SelectionActionBar
-        open={hasSelection}
-        selectionCount={selectionCount}
-        onDelete={removeItems}
+        empty={{ title: 'No locations found', icon: <MapPinXInside /> }}
+        onRowClick={
+          isGuest
+            ? undefined
+            : (item) =>
+                UpsertLocation.open('update-location', {
+                  action: 'Update',
+                  item,
+                })
+        }
+        selection={{
+          canSelect: can('locations', 'delete'),
+          items,
+          selection,
+          setSelection,
+          onDelete: removeItems,
+        }}
       />
       <UpsertLocation.Viewport />
     </>

--- a/src/app/(protected)/(team-management)/attendance/_components/AttendanceTable.tsx
+++ b/src/app/(protected)/(team-management)/attendance/_components/AttendanceTable.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useCallback } from 'react';
+import { useMemo } from 'react';
 
-import { Badge, Button, Table } from '@chakra-ui/react';
+import { Badge, Button } from '@chakra-ui/react';
 import {
   ClockAlert,
   ClockCheck,
@@ -10,11 +10,8 @@ import {
   UsersRound,
 } from 'lucide-react';
 
+import DataTable, { type Column } from '@/components/DataTable';
 import HighlightText from '@/components/HighlightText';
-import Pagination from '@/components/Pagination';
-import SelectionActionBar from '@/components/SelectionActionBar';
-import { Checkbox } from '@/components/ui/checkbox';
-import { EmptyState } from '@/components/ui/empty-state';
 import { toaster } from '@/components/ui/toaster';
 import Visibility from '@/components/Visibility';
 
@@ -23,13 +20,12 @@ import useTableState from '@/hooks/use-table-state';
 
 import { useAttendanceFilters } from '@/lib/nuqs';
 import { AttendanceStatus } from '@/utils/enum';
+import { buildPredicate } from '@/utils/filters';
 import { formatDatetime } from '@/utils/formatter';
 import { getColor } from '@/utils/helper';
 
 import { removeAttendance, updateStatus } from '@/actions/attendance';
 import { AttendanceWithPlayer } from '@/types/attendance';
-
-const HEADERS = ['Name', 'Status', 'Reason', 'Last Updated'] as const;
 
 const ACTIONS = [
   {
@@ -60,31 +56,23 @@ export default function AttendanceTable({
   const { isAdmin } = usePermissions();
   const [{ q, page, status }, setSearchParams] = useAttendanceFilters();
 
-  const predicate = useCallback(
-    (item: AttendanceWithPlayer) => {
-      const matchesSearch = item.player.user.name
-        .toLowerCase()
-        .includes(q.toLowerCase());
-      const matchesStatus = status.length === 0 || status.includes(item.status);
-
-      return matchesSearch && matchesStatus;
-    },
+  const predicate = useMemo(
+    () =>
+      buildPredicate<AttendanceWithPlayer>({
+        search: { query: q, fields: [(item) => item.player.user.name] },
+        match: { status },
+      }),
     [q, status],
   );
 
   const {
     items,
     currentData,
-    indeterminate,
     selection,
     setSelection,
-    hasSelection,
-    totalCount,
-    columnCount,
     selectionCount,
-  } = useTableState(attendances, predicate, page, {
-    headerCount: HEADERS.length,
-  });
+    totalCount,
+  } = useTableState(attendances, predicate, page);
 
   const removeItems = async () => {
     const results = await Promise.all(selection.map(removeAttendance));
@@ -121,100 +109,46 @@ export default function AttendanceTable({
     }
   };
 
-  return (
-    <>
-      <Table.ScrollArea>
-        <Table.Root
-          borderWidth={1}
-          size={{ base: 'sm', md: 'md' }}
-          interactive={totalCount > 0}
+  const columns: Array<Column<AttendanceWithPlayer>> = [
+    {
+      header: 'Name',
+      cell: (item) => (
+        <HighlightText query={q}>{item.player.user.name}</HighlightText>
+      ),
+    },
+    {
+      header: 'Status',
+      cell: (item) => (
+        <Badge
+          size="sm"
+          variant="surface"
+          borderRadius="full"
+          colorPalette={getColor(item.status)}
         >
-          <Table.Header>
-            <Table.Row>
-              <Visibility isVisible={isAdmin}>
-                <Table.ColumnHeader width={5}>
-                  <Checkbox
-                    top={0.5}
-                    aria-label="Select all rows"
-                    checked={
-                      indeterminate ? 'indeterminate' : selectionCount > 0
-                    }
-                    onCheckedChange={(changes) => {
-                      setSelection(
-                        changes.checked
-                          ? items.map(({ attendance_id }) => attendance_id)
-                          : [],
-                      );
-                    }}
-                  />
-                </Table.ColumnHeader>
-              </Visibility>
-              {HEADERS.map((header) => (
-                <Table.ColumnHeader key={header}>{header}</Table.ColumnHeader>
-              ))}
-            </Table.Row>
-          </Table.Header>
-          <Table.Body>
-            {currentData.length > 0 ? (
-              currentData.map((item) => (
-                <Table.Row key={item.attendance_id}>
-                  <Visibility isVisible={isAdmin}>
-                    <Table.Cell onClick={(e) => e.stopPropagation()}>
-                      <Checkbox
-                        top={0.5}
-                        aria-label="Select row"
-                        checked={selection.includes(item.attendance_id)}
-                        onCheckedChange={(changes) => {
-                          setSelection((prev) =>
-                            changes.checked
-                              ? [...prev, item.attendance_id]
-                              : prev.filter((id) => id !== item.attendance_id),
-                          );
-                        }}
-                      />
-                    </Table.Cell>
-                  </Visibility>
-                  <Table.Cell>
-                    <HighlightText query={q}>
-                      {item.player.user.name}
-                    </HighlightText>
-                  </Table.Cell>
-                  <Table.Cell>
-                    <Badge
-                      size="sm"
-                      variant="outline"
-                      borderRadius="full"
-                      colorPalette={getColor(item.status)}
-                    >
-                      {item.status}
-                    </Badge>
-                  </Table.Cell>
-                  <Table.Cell>{item.reason || '-'}</Table.Cell>
-                  <Table.Cell>{formatDatetime(item.updated_at)}</Table.Cell>
-                </Table.Row>
-              ))
-            ) : (
-              <Table.Row>
-                <Table.Cell colSpan={columnCount}>
-                  <EmptyState title="No players found" icon={<UsersRound />} />
-                </Table.Cell>
-              </Table.Row>
-            )}
-          </Table.Body>
-        </Table.Root>
-      </Table.ScrollArea>
+          {item.status}
+        </Badge>
+      ),
+    },
+    { header: 'Reason', cell: (item) => item.reason },
+    { header: 'Last Updated', cell: (item) => formatDatetime(item.updated_at) },
+  ];
 
-      <Pagination
-        count={totalCount}
-        page={page}
-        onPageChange={setSearchParams}
-      />
-      <SelectionActionBar
-        open={hasSelection}
-        selectionCount={selectionCount}
-        onDelete={removeItems}
-      >
-        {ACTIONS.map(({ label, value, icon: Icon, color }) => (
+  return (
+    <DataTable
+      columns={columns}
+      rowId={(item) => item.attendance_id}
+      currentData={currentData}
+      totalCount={totalCount}
+      page={page}
+      onPageChange={setSearchParams}
+      empty={{ title: 'No players found', icon: <UsersRound /> }}
+      selection={{
+        canSelect: isAdmin,
+        items,
+        selection,
+        setSelection,
+        onDelete: removeItems,
+        actions: ACTIONS.map(({ label, value, icon: Icon, color }) => (
           <Visibility key={value} isVisible={!status.includes(value)}>
             <Button
               size="sm"
@@ -226,8 +160,8 @@ export default function AttendanceTable({
               {label}
             </Button>
           </Visibility>
-        ))}
-      </SelectionActionBar>
-    </>
+        )),
+      }}
+    />
   );
 }

--- a/src/app/(protected)/(team-management)/matches/_components/MatchTable.tsx
+++ b/src/app/(protected)/(team-management)/matches/_components/MatchTable.tsx
@@ -2,18 +2,15 @@
 
 import { useCallback, useTransition } from 'react';
 
-import { Badge, HStack, Span, Table } from '@chakra-ui/react';
+import { Badge, HStack, Span } from '@chakra-ui/react';
 
-import Authorized from '@/components/Authorized';
 import { LeagueLink } from '@/components/common/LeagueSelection';
 import { LocationLink } from '@/components/common/LocationSelection';
+import DataTable, { type Column } from '@/components/DataTable';
 import HighlightText from '@/components/HighlightText';
-import Pagination from '@/components/Pagination';
-import SelectionActionBar from '@/components/SelectionActionBar';
-import { Checkbox } from '@/components/ui/checkbox';
-import { EmptyState } from '@/components/ui/empty-state';
 import { toaster } from '@/components/ui/toaster';
 
+import usePermissions from '@/hooks/use-permissions';
 import useTableState from '@/hooks/use-table-state';
 
 import { useMatchFilters } from '@/lib/nuqs';
@@ -24,20 +21,12 @@ import { getColor } from '@/utils/helper';
 import { removeMatch } from '@/actions/match';
 import { UpsertMatch } from './UpsertMatch';
 
-const HEADERS = [
-  'Opponent',
-  'League',
-  'Score',
-  'Result',
-  'Location',
-  'Date',
-] as const;
-
 export default function MatchTable({
   matches,
 }: {
   matches: Array<MatchWithTeams>;
 }) {
+  const { can } = usePermissions();
   const [isPending, startTransition] = useTransition();
   const [{ q, page }, setSearchParams] = useMatchFilters();
 
@@ -46,19 +35,8 @@ export default function MatchTable({
       item.away_team.name.toLowerCase().includes(q.toLowerCase()),
     [q],
   );
-  const {
-    items,
-    currentData,
-    indeterminate,
-    selection,
-    setSelection,
-    hasSelection,
-    totalCount,
-    columnCount,
-    selectionCount,
-  } = useTableState(matches, predicate, page, {
-    headerCount: HEADERS.length,
-  });
+  const { items, currentData, selection, setSelection, totalCount } =
+    useTableState(matches, predicate, page);
 
   const removeItems = async () => {
     const id = toaster.create({
@@ -82,127 +60,75 @@ export default function MatchTable({
     });
   };
 
+  const columns: Array<Column<MatchWithTeams>> = [
+    {
+      header: 'Opponent',
+      cell: (item) => (
+        <HighlightText query={q}>{item.away_team.name}</HighlightText>
+      ),
+    },
+    {
+      header: 'League',
+      cell: (item) => <LeagueLink name={item.league?.name} />,
+    },
+    {
+      header: 'Score',
+      cell: (item) => `${item.home_team_score} - ${item.away_team_score}`,
+    },
+    {
+      header: 'Result',
+      cell: (item) => (
+        <Badge
+          variant="surface"
+          borderRadius="full"
+          colorPalette={getColor(item.result)}
+        >
+          {item.result}
+        </Badge>
+      ),
+    },
+    {
+      header: 'Location',
+      cell: (item) => <LocationLink name={item.location?.name} />,
+    },
+    {
+      header: 'Date',
+      cell: (item) => (
+        <HStack gap={1}>
+          <Span fontSize="sm">{formatDay(item.date)}</Span>
+          <Span color="gray.400">&bull;</Span>
+          <Span fontSize="sm">{formatDate(item.date)}</Span>
+          <Span color="gray.400">&bull;</Span>
+          <Span fontSize="sm">{item.time}</Span>
+        </HStack>
+      ),
+    },
+  ];
+
   return (
     <>
-      <Table.ScrollArea>
-        <Table.Root
-          borderWidth={1}
-          size={{ base: 'sm', md: 'md' }}
-          interactive={totalCount > 0}
-        >
-          <Table.Header>
-            <Table.Row>
-              <Authorized resource="matches" action="delete">
-                <Table.ColumnHeader width={6}>
-                  <Checkbox
-                    top={0.5}
-                    aria-label="Select all rows"
-                    disabled={isPending}
-                    checked={
-                      indeterminate ? 'indeterminate' : selectionCount > 0
-                    }
-                    onCheckedChange={(changes) => {
-                      setSelection(
-                        changes.checked
-                          ? items.map(({ match_id }) => match_id)
-                          : [],
-                      );
-                    }}
-                  />
-                </Table.ColumnHeader>
-              </Authorized>
-              {HEADERS.map((header) => (
-                <Table.ColumnHeader key={header}>{header}</Table.ColumnHeader>
-              ))}
-            </Table.Row>
-          </Table.Header>
-          <Table.Body>
-            {currentData.length > 0 ? (
-              currentData.map((item) => (
-                <Table.Row
-                  key={item.match_id}
-                  _hover={{ cursor: 'pointer' }}
-                  onClick={() => {
-                    UpsertMatch.open('update-match', {
-                      action: 'Update',
-                      item: {
-                        ...item,
-                        away_team: item.away_team.team_id,
-                      },
-                    });
-                  }}
-                >
-                  <Authorized resource="matches" action="delete">
-                    <Table.Cell onClick={(e) => e.stopPropagation()}>
-                      <Checkbox
-                        top={0.5}
-                        aria-label="Select row"
-                        disabled={isPending}
-                        checked={selection.includes(item.match_id)}
-                        onCheckedChange={(changes) => {
-                          setSelection((prev) =>
-                            changes.checked
-                              ? [...prev, item.match_id]
-                              : prev.filter((id) => id !== item.match_id),
-                          );
-                        }}
-                      />
-                    </Table.Cell>
-                  </Authorized>
-                  <Table.Cell>
-                    <HighlightText query={q}>
-                      {item.away_team.name}
-                    </HighlightText>
-                  </Table.Cell>
-                  <Table.Cell>
-                    <LeagueLink name={item.league?.name} />
-                  </Table.Cell>
-                  <Table.Cell>
-                    {item.home_team_score} - {item.away_team_score}
-                  </Table.Cell>
-                  <Table.Cell>
-                    <Badge
-                      variant="surface"
-                      borderRadius="full"
-                      colorPalette={getColor(item.result)}
-                    >
-                      {item.result}
-                    </Badge>
-                  </Table.Cell>
-                  <Table.Cell>
-                    <LocationLink name={item.location?.name} />
-                  </Table.Cell>
-                  <Table.Cell>
-                    <HStack gap={1}>
-                      <Span fontSize="sm">{formatDay(item.date)}</Span>
-                      <Span color="gray.400">&bull;</Span>
-                      <Span fontSize="sm">{formatDate(item.date)}</Span>
-                      <Span color="gray.400">&bull;</Span>
-                      <Span fontSize="sm">{item.time}</Span>
-                    </HStack>
-                  </Table.Cell>
-                </Table.Row>
-              ))
-            ) : (
-              <Table.Row>
-                <Table.Cell colSpan={columnCount}>
-                  <EmptyState title="No matches found" />
-                </Table.Cell>
-              </Table.Row>
-            )}
-          </Table.Body>
-        </Table.Root>
-      </Table.ScrollArea>
-
-      <Pagination
-        count={totalCount}
+      <DataTable
+        columns={columns}
+        rowId={(item) => item.match_id}
+        currentData={currentData}
+        totalCount={totalCount}
         page={page}
         onPageChange={setSearchParams}
-      />
-      <SelectionActionBar
-        open={hasSelection}
-        selectionCount={selectionCount}
-        onDelete={removeItems}
+        empty={{ title: 'No matches found' }}
+        onRowClick={(item) =>
+          UpsertMatch.open('update-match', {
+            action: 'Update',
+            item: { ...item, away_team: item.away_team.team_id },
+          })
+        }
+        selection={{
+          canSelect: can('matches', 'delete'),
+          items,
+          selection,
+          setSelection,
+          disabled: isPending,
+          onDelete: removeItems,
+        }}
       />
       <UpsertMatch.Viewport />
     </>

--- a/src/app/(protected)/(team-management)/matches/_components/UpsertMatch.tsx
+++ b/src/app/(protected)/(team-management)/matches/_components/UpsertMatch.tsx
@@ -138,7 +138,7 @@ export const UpsertMatch = createOverlay(({ action, item, ...rest }) => {
                           {item.name}
                           <Badge
                             size="xs"
-                            variant="outline"
+                            variant="surface"
                             marginLeft="auto"
                             borderRadius="full"
                             colorPalette={getColor(item.status)}

--- a/src/app/(protected)/(team-management)/registration/_components/PreviewPanel.tsx
+++ b/src/app/(protected)/(team-management)/registration/_components/PreviewPanel.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
-import { Box, Button, HStack, Spinner, Table, Text } from '@chakra-ui/react';
+import { Box, Button, HStack, Spinner, Text } from '@chakra-ui/react';
 import {
   Eye,
   FileDown,
@@ -11,9 +11,12 @@ import {
   Table as TableIcon,
 } from 'lucide-react';
 
+import DataTable, { type Column } from '@/components/DataTable';
 import { Card } from '@/components/ui/card';
 import { EmptyState } from '@/components/ui/empty-state';
 import { toaster } from '@/components/ui/toaster';
+
+import useTableState from '@/hooks/use-table-state';
 
 import { League } from '@/drizzle/schema';
 import { User } from '@/drizzle/schema/user';
@@ -145,37 +148,43 @@ export default function PreviewPanel({
   );
 }
 
+const PAGE_SIZE = 10;
+
 function TablePreview({ players }: { players: Array<User> }) {
+  const [page, setPage] = useState(1);
+
+  const predicate = useCallback(() => true, []);
+  const { currentData, totalCount } = useTableState(players, predicate, page, {
+    pageSize: PAGE_SIZE,
+  });
+
+  const columns: Array<Column<User>> = [
+    {
+      header: '#',
+      cell: (_player, index) => (page - 1) * PAGE_SIZE + index + 1,
+      cellProps: { color: 'fg.muted' },
+    },
+    ...COLUMNS.map(
+      (column): Column<User> => ({
+        header: column.header,
+        cell: (player) => toRow(player)[column.key],
+      }),
+    ),
+  ];
+
   return (
-    <Table.ScrollArea>
-      <Table.Root size="sm" borderWidth={1}>
-        <Table.Header>
-          <Table.Row>
-            <Table.ColumnHeader>#</Table.ColumnHeader>
-            {COLUMNS.map((column) => (
-              <Table.ColumnHeader key={column.key}>
-                {column.header}
-              </Table.ColumnHeader>
-            ))}
-          </Table.Row>
-        </Table.Header>
-        <Table.Body>
-          {players.map((player, index) => {
-            const row = toRow(player);
-            return (
-              <Table.Row key={player.id}>
-                <Table.Cell color="fg.muted">{index + 1}</Table.Cell>
-                {COLUMNS.map((column) => (
-                  <Table.Cell key={column.key}>
-                    {row[column.key] || '-'}
-                  </Table.Cell>
-                ))}
-              </Table.Row>
-            );
-          })}
-        </Table.Body>
-      </Table.Root>
-    </Table.ScrollArea>
+    <DataTable
+      size="sm"
+      columns={columns}
+      rowId={(player) => player.id}
+      page={page}
+      pageSize={PAGE_SIZE}
+      totalCount={totalCount}
+      currentData={currentData}
+      onPageChange={({ page }) => setPage(page)}
+      marginBottom={2}
+      empty={{ title: 'No players to preview', icon: <TableIcon /> }}
+    />
   );
 }
 

--- a/src/app/(protected)/(team-management)/registration/_components/SavedRegistrations.tsx
+++ b/src/app/(protected)/(team-management)/registration/_components/SavedRegistrations.tsx
@@ -2,15 +2,14 @@
 
 import { useCallback, useState } from 'react';
 
-import { HStack, IconButton, Table } from '@chakra-ui/react';
+import { Box, HStack, IconButton } from '@chakra-ui/react';
 import { Base64 } from 'js-base64';
 import { Download, Trash2 } from 'lucide-react';
 
+import DataTable, { type Column } from '@/components/DataTable';
 import HighlightText from '@/components/HighlightText';
-import Pagination from '@/components/Pagination';
 import SearchInput from '@/components/SearchInput';
 import { Card } from '@/components/ui/card';
-import { EmptyState } from '@/components/ui/empty-state';
 import { toaster } from '@/components/ui/toaster';
 
 import useTableState from '@/hooks/use-table-state';
@@ -19,8 +18,6 @@ import { formatDatetime } from '@/utils/formatter';
 
 import { downloadPdf } from '../_helpers/pdf';
 import { SavedRegistration } from '../_helpers/useSavedRegistrations';
-
-const HEADERS = ['Name', 'Players', 'Date saved', 'Actions'] as const;
 
 type SavedRegistrationsProps = {
   items: Array<SavedRegistration>;
@@ -39,9 +36,7 @@ export default function SavedRegistrations({
       item.leagueName.toLowerCase().includes(q.toLowerCase()),
     [q],
   );
-  const { currentData, totalCount } = useTableState(items, predicate, page, {
-    headerCount: HEADERS.length,
-  });
+  const { currentData, totalCount } = useTableState(items, predicate, page);
 
   const handleDownload = (item: SavedRegistration) => {
     setIsDownloading(true);
@@ -85,78 +80,69 @@ export default function SavedRegistrations({
     });
   };
 
+  const columns: Array<Column<SavedRegistration>> = [
+    {
+      header: 'Name',
+      cellProps: { fontWeight: 'medium' },
+      cell: (item) => (
+        <HighlightText query={q}>{item.leagueName}</HighlightText>
+      ),
+    },
+    { header: 'Players', cell: (item) => item.playerCount },
+    {
+      header: 'Date saved',
+      cellProps: { whiteSpace: 'nowrap' },
+      cell: (item) => formatDatetime(item.savedAt),
+    },
+    {
+      header: 'Actions',
+      cell: (item) => (
+        <HStack gap={1}>
+          <IconButton
+            size="xs"
+            variant="ghost"
+            hidden={!item.pdfBase64}
+            disabled={isDownloading}
+            onClick={() => handleDownload(item)}
+          >
+            <Download />
+          </IconButton>
+          <IconButton
+            size="xs"
+            variant="ghost"
+            colorPalette="red"
+            disabled={isDownloading}
+            onClick={() => handleRemove(item)}
+          >
+            <Trash2 />
+          </IconButton>
+        </HStack>
+      ),
+    },
+  ];
+
   return (
     <Card
       title="Saved registrations"
       description="Recent league registrations you have saved."
     >
-      <SearchInput placeholder="Filter by name..." />
+      <Box marginBlock={4}>
+        <SearchInput placeholder="Filter by name..." />
+      </Box>
 
-      <Table.ScrollArea marginBlock={4}>
-        <Table.Root size="sm">
-          <Table.Header>
-            <Table.Row>
-              {HEADERS.map((header) => (
-                <Table.ColumnHeader key={header} paddingBlock={3}>
-                  {header}
-                </Table.ColumnHeader>
-              ))}
-            </Table.Row>
-          </Table.Header>
-          <Table.Body>
-            {currentData.length > 0 ? (
-              currentData.map((item) => (
-                <Table.Row key={item.id}>
-                  <Table.Cell fontWeight="medium">
-                    <HighlightText query={q}>{item.leagueName}</HighlightText>
-                  </Table.Cell>
-                  <Table.Cell>{item.playerCount}</Table.Cell>
-                  <Table.Cell whiteSpace="nowrap">
-                    {formatDatetime(item.savedAt)}
-                  </Table.Cell>
-                  <Table.Cell>
-                    <HStack gap={1}>
-                      <IconButton
-                        size="xs"
-                        variant="ghost"
-                        hidden={!item.pdfBase64}
-                        disabled={isDownloading}
-                        onClick={() => handleDownload(item)}
-                      >
-                        <Download />
-                      </IconButton>
-                      <IconButton
-                        size="xs"
-                        variant="ghost"
-                        colorPalette="red"
-                        disabled={isDownloading}
-                        onClick={() => handleRemove(item)}
-                      >
-                        <Trash2 />
-                      </IconButton>
-                    </HStack>
-                  </Table.Cell>
-                </Table.Row>
-              ))
-            ) : (
-              <Table.Row>
-                <Table.Cell colSpan={HEADERS.length}>
-                  <EmptyState
-                    size="sm"
-                    title="No saved registrations yet"
-                    description="Click Save in the preview to keep a registration here."
-                  />
-                </Table.Cell>
-              </Table.Row>
-            )}
-          </Table.Body>
-        </Table.Root>
-      </Table.ScrollArea>
-
-      <Pagination
-        count={totalCount}
+      <DataTable
+        columns={columns}
+        rowId={(item) => item.id}
+        currentData={currentData}
+        totalCount={totalCount}
         page={page}
         onPageChange={setSearchParams}
+        empty={{
+          title: 'No saved registrations yet',
+          description: 'Click Save in the preview to keep a registration here.',
+        }}
+        size="sm"
+        borderWidth={undefined}
       />
     </Card>
   );

--- a/src/app/(protected)/(team-management)/registration/_components/main.tsx
+++ b/src/app/(protected)/(team-management)/registration/_components/main.tsx
@@ -283,14 +283,12 @@ export default function RegistrationPageClient() {
         </GridItem>
 
         <GridItem colSpan={{ base: 1, lg: 7 }}>
-          <Stack gap={6}>
-            <PreviewPanel
-              players={selection}
-              league={league}
-              template={template}
-              onSave={handleSave}
-            />
-          </Stack>
+          <PreviewPanel
+            players={selection}
+            league={league}
+            template={template}
+            onSave={handleSave}
+          />
         </GridItem>
 
         <GridItem colSpan={{ base: 1, lg: 12 }}>

--- a/src/app/(protected)/(team-management)/roster/_components/RosterTable.tsx
+++ b/src/app/(protected)/(team-management)/roster/_components/RosterTable.tsx
@@ -1,29 +1,24 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { useCallback, useMemo } from 'react';
+import { useMemo } from 'react';
 
-import { Badge, Icon, Table } from '@chakra-ui/react';
-import { Check, Loader, SwatchBook } from 'lucide-react';
+import { Badge, Icon } from '@chakra-ui/react';
+import { ShieldAlert, ShieldCheck, SwatchBook } from 'lucide-react';
 
+import DataTable, { type Column } from '@/components/DataTable';
 import HighlightText from '@/components/HighlightText';
-import Pagination from '@/components/Pagination';
-import SelectionActionBar from '@/components/SelectionActionBar';
-import Visibility from '@/components/Visibility';
-import { Checkbox } from '@/components/ui/checkbox';
-import { EmptyState } from '@/components/ui/empty-state';
 import { toaster } from '@/components/ui/toaster';
 
 import usePermissions from '@/hooks/use-permissions';
 import useTableState from '@/hooks/use-table-state';
 
 import { useRosterFilters } from '@/lib/nuqs';
+import { buildPredicate } from '@/utils/filters';
 import { getColor } from '@/utils/helper';
 
 import { removeUser } from '@/actions/user';
 import { User } from '@/drizzle/schema/user';
-
-const HEADERS = ['No.', 'Name', 'Email', 'State', 'Roles', 'Position'] as const;
 
 const mask = (cc: string, num = 4) =>
   `${cc}`.slice(-num).padStart(`${cc}`.length, '*');
@@ -35,31 +30,16 @@ export default function RosterTable({ users }: { users: Array<User> }) {
 
   const canManage = isAdmin || isCaptain;
 
-  const predicate = useCallback(
-    (user: User) =>
-      (user.name.toLowerCase().includes(q.toLowerCase()) ||
-        user.email.toLowerCase().includes(q.toLowerCase())) &&
-      (state.length === 0 || state.includes(user.state)) &&
-      (role.length === 0 || role.includes(user.role)),
+  const predicate = useMemo(
+    () =>
+      buildPredicate<User>({
+        search: { query: q, fields: ['name', 'email'] },
+        match: { state, role },
+      }),
     [q, state, role],
   );
-
-  const {
-    items,
-    currentData,
-    indeterminate,
-    selection,
-    setSelection,
-    hasSelection,
-    totalCount,
-    selectionCount,
-  } = useTableState(users, predicate, page);
-
-  // No., Name, Email, State, Roles, Position (+ checkbox & verified for managers)
-  const columnCount = useMemo(
-    () => HEADERS.length + (canManage ? 2 : 0),
-    [canManage],
-  );
+  const { items, currentData, selection, setSelection, totalCount } =
+    useTableState(users, predicate, page);
 
   const removeUsers = async () => {
     const results = await Promise.all(selection.map(removeUser));
@@ -76,135 +56,91 @@ export default function RosterTable({ users }: { users: Array<User> }) {
     setSelection([]);
   };
 
-  return (
-    <>
-      <Table.ScrollArea>
-        <Table.Root
-          borderWidth={1}
-          size={{ base: 'sm', md: 'md' }}
-          stickyHeader
-          interactive={totalCount > 0}
+  const columns: Array<Column<User>> = [
+    ...(canManage
+      ? [
+          {
+            header: 'Verified',
+            align: 'center',
+            cell: (user: User) =>
+              user.emailVerified ? (
+                <Icon as={ShieldCheck} size="sm" color="green.500" />
+              ) : (
+                <Icon as={ShieldAlert} size="sm" color="orange.500" />
+              ),
+          } satisfies Column<User>,
+        ]
+      : []),
+    { header: 'No.', cell: (user) => user.player?.jersey_number ?? '-' },
+    {
+      header: 'Name',
+      cell: (user) => (
+        <HighlightText query={q}>
+          {isGuest ? mask(user.name, -4) : user.name}
+        </HighlightText>
+      ),
+    },
+    {
+      header: 'Email',
+      cell: (user) => (
+        <HighlightText query={q}>
+          {isGuest ? mask(user.email, -4) : user.email}
+        </HighlightText>
+      ),
+    },
+    {
+      header: 'State',
+      cell: (user) => (
+        <Badge
+          variant="surface"
+          borderRadius="full"
+          colorPalette={getColor(user.state)}
         >
-          <Table.Header>
-            <Table.Row>
-              <Visibility isVisible={canManage}>
-                <>
-                  <Table.ColumnHeader width={6}>
-                    <Checkbox
-                      top={0.5}
-                      aria-label="Select all rows"
-                      checked={
-                        indeterminate ? 'indeterminate' : selectionCount > 0
-                      }
-                      onCheckedChange={(changes) => {
-                        setSelection(
-                          changes.checked ? items.map(({ id }) => id) : [],
-                        );
-                      }}
-                    />
-                  </Table.ColumnHeader>
-                  <Table.ColumnHeader textAlign="center">
-                    Verified
-                  </Table.ColumnHeader>
-                </>
-              </Visibility>
-              {HEADERS.map((header) => (
-                <Table.ColumnHeader key={header}>{header}</Table.ColumnHeader>
-              ))}
-            </Table.Row>
-          </Table.Header>
-          <Table.Body>
-            {currentData.length > 0 ? (
-              currentData.map((user) => (
-                <Table.Row
-                  key={user.id}
-                  data-selected={selection.includes(user.id) ? '' : undefined}
-                  _hover={{ cursor: isGuest ? 'default' : 'pointer' }}
-                  onClick={() => {
-                    if (isGuest) return;
-                    router.replace('/profile/' + user.id);
-                  }}
-                >
-                  <Visibility isVisible={canManage}>
-                    <Table.Cell onClick={(e) => e.stopPropagation()}>
-                      <Checkbox
-                        top={0.5}
-                        aria-label="Select row"
-                        checked={selection.includes(user.id)}
-                        onCheckedChange={(changes) => {
-                          setSelection((prev) =>
-                            changes.checked
-                              ? [...prev, user.id]
-                              : selection.filter((id) => id !== user.id),
-                          );
-                        }}
-                      />
-                    </Table.Cell>
-                    <Table.Cell textAlign="center">
-                      {user.emailVerified ? (
-                        <Icon as={Check} size="sm" color="green.500" />
-                      ) : (
-                        <Icon as={Loader} size="sm" color="orange.500" />
-                      )}
-                    </Table.Cell>
-                  </Visibility>
-                  <Table.Cell>{user.player?.jersey_number ?? '-'}</Table.Cell>
-                  <Table.Cell>
-                    <HighlightText query={q}>
-                      {isGuest ? mask(user.name, -4) : user.name}
-                    </HighlightText>
-                  </Table.Cell>
-                  <Table.Cell>
-                    <HighlightText query={q}>
-                      {isGuest ? mask(user.email, -4) : user.email}
-                    </HighlightText>
-                  </Table.Cell>
-                  <Table.Cell>
-                    <Badge
-                      variant="surface"
-                      borderRadius="full"
-                      colorPalette={getColor(user.state)}
-                    >
-                      {user.state}
-                    </Badge>
-                  </Table.Cell>
-                  <Table.Cell>
-                    <Badge variant="outline" borderRadius="full">
-                      {user.role}
-                    </Badge>
-                  </Table.Cell>
-                  <Table.Cell>
-                    {user.player?.position ? (
-                      <Badge variant="outline" borderRadius="full">
-                        {user.player.position}
-                      </Badge>
-                    ) : (
-                      '-'
-                    )}
-                  </Table.Cell>
-                </Table.Row>
-              ))
-            ) : (
-              <Table.Row>
-                <Table.Cell colSpan={columnCount}>
-                  <EmptyState icon={<SwatchBook />} title="No users found" />
-                </Table.Cell>
-              </Table.Row>
-            )}
-          </Table.Body>
-        </Table.Root>
-      </Table.ScrollArea>
+          {user.state}
+        </Badge>
+      ),
+    },
+    {
+      header: 'Roles',
+      cell: (user) => (
+        <Badge variant="outline" borderRadius="full">
+          {user.role}
+        </Badge>
+      ),
+    },
+    {
+      header: 'Position',
+      cell: (user) =>
+        user.player?.position ? (
+          <Badge variant="outline" borderRadius="full">
+            {user.player.position}
+          </Badge>
+        ) : (
+          '-'
+        ),
+    },
+  ];
 
-      <Pagination
-        count={totalCount}
-        page={page}
-        onPageChange={setSearchParams}
-      />
-      <SelectionActionBar
-        open={hasSelection}
-        selectionCount={selectionCount}
-        onDelete={removeUsers}
-      />
-    </>
+  return (
+    <DataTable
+      columns={columns}
+      rowId={(user) => user.id}
+      currentData={currentData}
+      totalCount={totalCount}
+      page={page}
+      onPageChange={setSearchParams}
+      empty={{ title: 'No users found', icon: <SwatchBook /> }}
+      stickyHeader
+      onRowClick={
+        isGuest ? undefined : (user) => router.replace('/profile/' + user.id)
+      }
+      selection={{
+        canSelect: canManage,
+        items,
+        selection,
+        setSelection,
+        onDelete: removeUsers,
+      }}
+    />
   );
 }

--- a/src/app/(protected)/(team-management)/training/_components/SessionTable.tsx
+++ b/src/app/(protected)/(team-management)/training/_components/SessionTable.tsx
@@ -9,17 +9,12 @@ import {
   HStack,
   List,
   Span,
-  Table,
 } from '@chakra-ui/react';
 import { CirclePile } from 'lucide-react';
 
-import Authorized from '@/components/Authorized';
 import { LocationLink } from '@/components/common/LocationSelection';
+import DataTable, { type Column } from '@/components/DataTable';
 import HighlightText from '@/components/HighlightText';
-import Pagination from '@/components/Pagination';
-import SelectionActionBar from '@/components/SelectionActionBar';
-import { Checkbox } from '@/components/ui/checkbox';
-import { EmptyState } from '@/components/ui/empty-state';
 import { toaster } from '@/components/ui/toaster';
 import { Tooltip } from '@/components/ui/tooltip';
 
@@ -35,14 +30,12 @@ import { getColor } from '@/utils/helper';
 import { removeSession } from '@/actions/training-session';
 import { UpsertSession } from './UpsertSession';
 
-const HEADERS = ['Date', 'Time', 'Location', 'Status', 'Present Rate'] as const;
-
 export default function SessionTable({
   sessions,
 }: {
   sessions: Array<TrainingSessionWithDetails>;
 }) {
-  const { isGuest } = usePermissions();
+  const { can, isGuest } = usePermissions();
   const [{ q, page }, setSearchParams] = useTrainingFilters();
 
   const predicate = useCallback(
@@ -50,19 +43,8 @@ export default function SessionTable({
       (item.location?.name ?? '').toLowerCase().includes(q.toLowerCase()),
     [q],
   );
-  const {
-    items,
-    currentData,
-    indeterminate,
-    selection,
-    setSelection,
-    hasSelection,
-    totalCount,
-    columnCount,
-    selectionCount,
-  } = useTableState(sessions, predicate, page, {
-    headerCount: HEADERS.length,
-  });
+  const { items, currentData, selection, setSelection, totalCount } =
+    useTableState(sessions, predicate, page);
 
   const removeItems = async () => {
     const results = await Promise.all(selection.map(removeSession));
@@ -79,145 +61,95 @@ export default function SessionTable({
     setSelection([]);
   };
 
+  const columns: Array<Column<TrainingSessionWithDetails>> = [
+    {
+      header: 'Date',
+      cell: (item) => (
+        <ChakraLink colorPalette="blue" asChild>
+          <NextLink
+            href={{ pathname: '/attendance', query: { date: item.date } }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <HStack>
+              <Span>{formatDay(item.date)}</Span>
+              <Span color="gray.400">&bull;</Span>
+              <Span>{formatDate(item.date)}</Span>
+            </HStack>
+          </NextLink>
+        </ChakraLink>
+      ),
+    },
+    {
+      header: 'Time',
+      cell: (item) => (
+        <HStack gap={1}>
+          <Span>{item.start_time}</Span>
+          <Span color="gray.400">&rarr;</Span>
+          <Span>{item.end_time}</Span>
+        </HStack>
+      ),
+    },
+    {
+      header: 'Location',
+      cell: (item) => (
+        <LocationLink name={item.location?.name}>
+          <HighlightText query={q}>{item.location?.name ?? '-'}</HighlightText>
+        </LocationLink>
+      ),
+    },
+    {
+      header: 'Status',
+      cell: (item) => (
+        <Badge
+          variant="surface"
+          borderRadius="full"
+          colorPalette={getColor(item.status)}
+        >
+          {item.status}
+        </Badge>
+      ),
+    },
+    {
+      header: 'Present Rate',
+      cell: (item) => (
+        <Tooltip
+          content={
+            <List.Root paddingInline={4}>
+              <List.Item>On Time: {item.analytics.on_time}</List.Item>
+              <List.Item>Late: {item.analytics.late}</List.Item>
+            </List.Root>
+          }
+          interactive
+        >
+          <Span>{item.analytics.present_rate}%</Span>
+        </Tooltip>
+      ),
+    },
+  ];
+
   return (
     <>
-      <Table.ScrollArea>
-        <Table.Root
-          borderWidth={1}
-          size={{ base: 'sm', md: 'md' }}
-          interactive={totalCount > 0}
-        >
-          <Table.Header>
-            <Table.Row>
-              <Authorized resource="training" action="delete">
-                <Table.ColumnHeader width={6}>
-                  <Checkbox
-                    top={0.5}
-                    aria-label="Select all rows"
-                    checked={
-                      indeterminate ? 'indeterminate' : selectionCount > 0
-                    }
-                    onCheckedChange={(changes) => {
-                      setSelection(
-                        changes.checked
-                          ? items.map(({ session_id }) => session_id)
-                          : [],
-                      );
-                    }}
-                  />
-                </Table.ColumnHeader>
-              </Authorized>
-              {HEADERS.map((header) => (
-                <Table.ColumnHeader key={header}>{header}</Table.ColumnHeader>
-              ))}
-            </Table.Row>
-          </Table.Header>
-          <Table.Body>
-            {currentData.length > 0 ? (
-              currentData.map((item) => (
-                <Table.Row
-                  key={item.session_id}
-                  _hover={{ cursor: isGuest ? 'default' : 'pointer' }}
-                  onClick={() => {
-                    if (isGuest) return;
-                    UpsertSession.open('update-session', {
-                      action: 'Update',
-                      item,
-                    });
-                  }}
-                >
-                  <Authorized resource="training" action="delete">
-                    <Table.Cell onClick={(e) => e.stopPropagation()}>
-                      <Checkbox
-                        top={0.5}
-                        aria-label="Select row"
-                        checked={selection.includes(item.session_id)}
-                        onCheckedChange={(changes) => {
-                          setSelection((prev) =>
-                            changes.checked
-                              ? [...prev, item.session_id]
-                              : prev.filter((id) => id !== item.session_id),
-                          );
-                        }}
-                      />
-                    </Table.Cell>
-                  </Authorized>
-                  <Table.Cell>
-                    <ChakraLink colorPalette="blue" asChild>
-                      <NextLink
-                        href={{
-                          pathname: '/attendance',
-                          query: { date: item.date },
-                        }}
-                        onClick={(e) => e.stopPropagation()}
-                      >
-                        <HStack>
-                          <Span>{formatDay(item.date)}</Span>
-                          <Span color="gray.400">&bull;</Span>
-                          <Span>{formatDate(item.date)}</Span>
-                        </HStack>
-                      </NextLink>
-                    </ChakraLink>
-                  </Table.Cell>
-                  <Table.Cell>
-                    <HStack gap={1}>
-                      <Span>{item.start_time}</Span>
-                      <Span color="gray.400">&rarr;</Span>
-                      <Span>{item.end_time}</Span>
-                    </HStack>
-                  </Table.Cell>
-                  <Table.Cell>
-                    <LocationLink name={item.location?.name}>
-                      <HighlightText query={q}>
-                        {item.location?.name ?? '-'}
-                      </HighlightText>
-                    </LocationLink>
-                  </Table.Cell>
-                  <Table.Cell>
-                    <Badge
-                      variant="surface"
-                      borderRadius="full"
-                      colorPalette={getColor(item.status)}
-                    >
-                      {item.status}
-                    </Badge>
-                  </Table.Cell>
-                  <Tooltip
-                    content={
-                      <List.Root paddingInline={4}>
-                        <List.Item>On Time: {item.analytics.on_time}</List.Item>
-                        <List.Item>Late: {item.analytics.late}</List.Item>
-                      </List.Root>
-                    }
-                    interactive
-                  >
-                    <Table.Cell>{item.analytics.present_rate}%</Table.Cell>
-                  </Tooltip>
-                </Table.Row>
-              ))
-            ) : (
-              <Table.Row>
-                <Table.Cell colSpan={columnCount}>
-                  <EmptyState
-                    title="No training sessions found"
-                    icon={<CirclePile />}
-                  />
-                </Table.Cell>
-              </Table.Row>
-            )}
-          </Table.Body>
-        </Table.Root>
-      </Table.ScrollArea>
-
-      <Pagination
-        count={totalCount}
+      <DataTable
+        columns={columns}
+        rowId={(item) => item.session_id}
+        currentData={currentData}
+        totalCount={totalCount}
         page={page}
         onPageChange={setSearchParams}
-      />
-      <SelectionActionBar
-        open={hasSelection}
-        selectionCount={selectionCount}
-        onDelete={removeItems}
+        empty={{ title: 'No training sessions found', icon: <CirclePile /> }}
+        onRowClick={
+          isGuest
+            ? undefined
+            : (item) =>
+                UpsertSession.open('update-session', { action: 'Update', item })
+        }
+        selection={{
+          canSelect: can('training', 'delete'),
+          items,
+          selection,
+          setSelection,
+          onDelete: removeItems,
+        }}
       />
       <UpsertSession.Viewport />
     </>

--- a/src/app/(protected)/profile/_components/TeamInfo.tsx
+++ b/src/app/(protected)/profile/_components/TeamInfo.tsx
@@ -164,11 +164,7 @@ export default function TeamInfo({
         ) : (
           <SimpleGrid columns={{ base: 1, md: 2 }}>
             <TextField label="Role">
-              <Badge
-                variant="subtle"
-                colorPalette={getColor(user.role)}
-                borderRadius="full"
-              >
+              <Badge variant="outline" borderRadius="full">
                 {user.role}
               </Badge>
             </TextField>

--- a/src/components/DataTable.test.tsx
+++ b/src/components/DataTable.test.tsx
@@ -1,0 +1,102 @@
+import { renderWithUI, screen } from '@/test/utilities';
+
+import DataTable, { type Column } from './DataTable';
+
+type Row = { id: string; name: string; selectable: boolean };
+
+const ROWS: Array<Row> = [
+  { id: 'a', name: 'Alice', selectable: true },
+  { id: 'b', name: 'Bob', selectable: false },
+  { id: 'c', name: 'Carol', selectable: true },
+];
+
+const COLUMNS: Array<Column<Row>> = [
+  { header: 'Name', cell: (row) => row.name },
+];
+
+const baseProps = {
+  columns: COLUMNS,
+  rowId: (row: Row) => row.id,
+  currentData: ROWS,
+  totalCount: ROWS.length,
+  page: 1,
+  onPageChange: vi.fn(),
+  empty: { title: 'Nothing here' },
+};
+
+describe('DataTable', () => {
+  test('renders a header and a cell per row', () => {
+    renderWithUI(<DataTable {...baseProps} />);
+
+    expect(screen.getByText('Name')).toBeInTheDocument();
+    ['Alice', 'Bob', 'Carol'].forEach((name) =>
+      expect(screen.getByText(name)).toBeInTheDocument(),
+    );
+  });
+
+  test('shows the empty state when there is no data', () => {
+    renderWithUI(<DataTable {...baseProps} currentData={[]} totalCount={0} />);
+
+    expect(screen.getByText('Nothing here')).toBeInTheDocument();
+  });
+
+  test('omits the checkbox column when selection is absent', () => {
+    renderWithUI(<DataTable {...baseProps} />);
+
+    expect(
+      screen.queryByRole('checkbox', { name: 'Select all rows' }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('calls onRowClick with the clicked item', async () => {
+    const onRowClick = vi.fn();
+    const { user } = renderWithUI(
+      <DataTable {...baseProps} onRowClick={onRowClick} />,
+    );
+
+    await user.click(screen.getByText('Carol'));
+
+    expect(onRowClick).toHaveBeenCalledWith(ROWS[2]);
+  });
+
+  test('select-all selects only the selectable rows', async () => {
+    const setSelection = vi.fn();
+    const { user } = renderWithUI(
+      <DataTable
+        {...baseProps}
+        selection={{
+          canSelect: true,
+          items: ROWS,
+          selection: [],
+          setSelection,
+          isSelectable: (row) => row.selectable,
+          onDelete: vi.fn(),
+        }}
+      />,
+    );
+
+    await user.click(screen.getByRole('checkbox', { name: 'Select all rows' }));
+
+    expect(setSelection).toHaveBeenCalledWith(['a', 'c']);
+  });
+
+  test('marks the non-selectable row checkbox as disabled', () => {
+    const { container } = renderWithUI(
+      <DataTable
+        {...baseProps}
+        selection={{
+          canSelect: true,
+          items: ROWS,
+          selection: [],
+          setSelection: vi.fn(),
+          isSelectable: (row) => row.selectable,
+          onDelete: vi.fn(),
+        }}
+      />,
+    );
+
+    // 3 rows, one of which (Bob) is not selectable. Chakra reflects the
+    // disabled state via `data-disabled` on the checkbox root.
+    expect(container.querySelectorAll('label[data-disabled]')).toHaveLength(1);
+  });
+});

--- a/src/components/DataTable.test.tsx
+++ b/src/components/DataTable.test.tsx
@@ -24,6 +24,17 @@ const baseProps = {
   empty: { title: 'Nothing here' },
 };
 
+/** Build a `selection` prop with sane defaults, overridable per test. */
+const withSelection = (overrides = {}) => ({
+  canSelect: true,
+  items: ROWS,
+  selection: [] as Array<string>,
+  setSelection: vi.fn(),
+  isSelectable: (row: Row) => row.selectable,
+  onDelete: vi.fn(),
+  ...overrides,
+});
+
 describe('DataTable', () => {
   test('renders a header and a cell per row', () => {
     renderWithUI(<DataTable {...baseProps} />);
@@ -34,69 +45,314 @@ describe('DataTable', () => {
     );
   });
 
-  test('shows the empty state when there is no data', () => {
-    renderWithUI(<DataTable {...baseProps} currentData={[]} totalCount={0} />);
+  test('applies column alignment and header/cell props', () => {
+    const columns: Array<Column<Row>> = [
+      {
+        header: 'Name',
+        align: 'right',
+        headerProps: { className: 'name-header' },
+        cellProps: { className: 'name-cell' },
+        cell: (row) => row.name,
+      },
+    ];
+    const { container } = renderWithUI(
+      <DataTable {...baseProps} columns={columns} />,
+    );
 
-    expect(screen.getByText('Nothing here')).toBeInTheDocument();
+    expect(container.querySelector('th.name-header')).toBeInTheDocument();
+    expect(container.querySelectorAll('td.name-cell')).toHaveLength(
+      ROWS.length,
+    );
   });
 
-  test('omits the checkbox column when selection is absent', () => {
-    renderWithUI(<DataTable {...baseProps} />);
+  test('passes the row index to the cell renderer', () => {
+    const columns: Array<Column<Row>> = [
+      { header: '#', cell: (_row, index) => `row-${index}` },
+    ];
+    renderWithUI(<DataTable {...baseProps} columns={columns} />);
+
+    expect(screen.getByText('row-0')).toBeInTheDocument();
+    expect(screen.getByText('row-1')).toBeInTheDocument();
+    expect(screen.getByText('row-2')).toBeInTheDocument();
+  });
+
+  test('falls back to a dash when a cell renders nullish', () => {
+    const columns: Array<Column<Row>> = [{ header: 'Maybe', cell: () => null }];
+    renderWithUI(<DataTable {...baseProps} columns={columns} />);
+
+    expect(screen.getAllByText('-')).toHaveLength(ROWS.length);
+  });
+
+  test('shows the empty state (with description and icon) when there is no data', () => {
+    renderWithUI(
+      <DataTable
+        {...baseProps}
+        currentData={[]}
+        totalCount={0}
+        empty={{
+          title: 'Nothing here',
+          description: 'Try again later',
+          icon: <span data-testid="empty-icon" />,
+        }}
+      />,
+    );
+
+    expect(screen.getByText('Nothing here')).toBeInTheDocument();
+    expect(screen.getByText('Try again later')).toBeInTheDocument();
+    expect(screen.getByTestId('empty-icon')).toBeInTheDocument();
+  });
+
+  test('renders the empty state across the checkbox + data columns when selectable', () => {
+    const { container } = renderWithUI(
+      <DataTable
+        {...baseProps}
+        currentData={[]}
+        totalCount={0}
+        selection={withSelection()}
+      />,
+    );
+
+    // colSpan = columns (1) + checkbox column (1).
+    expect(container.querySelector('td[colspan="2"]')).toBeInTheDocument();
+  });
+
+  describe('without selection', () => {
+    test('omits the checkbox column', () => {
+      renderWithUI(<DataTable {...baseProps} />);
+
+      expect(
+        screen.queryByRole('checkbox', { name: 'Select all rows' }),
+      ).not.toBeInTheDocument();
+    });
+
+    test('does not render the selection action bar', () => {
+      renderWithUI(<DataTable {...baseProps} />);
+
+      expect(screen.queryByText('Delete')).not.toBeInTheDocument();
+    });
+  });
+
+  test('omits the checkbox column when canSelect is false', () => {
+    renderWithUI(
+      <DataTable
+        {...baseProps}
+        selection={withSelection({ canSelect: false })}
+      />,
+    );
 
     expect(
       screen.queryByRole('checkbox', { name: 'Select all rows' }),
     ).not.toBeInTheDocument();
+    expect(screen.queryByText('Delete')).not.toBeInTheDocument();
   });
 
-  test('calls onRowClick with the clicked item', async () => {
-    const onRowClick = vi.fn();
-    const { user } = renderWithUI(
-      <DataTable {...baseProps} onRowClick={onRowClick} />,
-    );
+  describe('row click', () => {
+    test('calls onRowClick with the clicked item', async () => {
+      const onRowClick = vi.fn();
+      const { user } = renderWithUI(
+        <DataTable {...baseProps} onRowClick={onRowClick} />,
+      );
 
-    await user.click(screen.getByText('Carol'));
+      await user.click(screen.getByText('Carol'));
 
-    expect(onRowClick).toHaveBeenCalledWith(ROWS[2]);
+      expect(onRowClick).toHaveBeenCalledWith(ROWS[2]);
+    });
+
+    test('stops propagation so toggling a checkbox never triggers the row click', async () => {
+      const onRowClick = vi.fn();
+      const { container, user } = renderWithUI(
+        <DataTable
+          {...baseProps}
+          onRowClick={onRowClick}
+          selection={withSelection()}
+        />,
+      );
+
+      // The checkbox lives in the first cell of the row; clicking that cell
+      // must not bubble up to the row's onClick handler.
+      const checkboxCell = container.querySelector('tbody tr td');
+      await user.click(checkboxCell as Element);
+
+      expect(onRowClick).not.toHaveBeenCalled();
+    });
   });
 
-  test('select-all selects only the selectable rows', async () => {
-    const setSelection = vi.fn();
-    const { user } = renderWithUI(
-      <DataTable
-        {...baseProps}
-        selection={{
-          canSelect: true,
-          items: ROWS,
-          selection: [],
-          setSelection,
-          isSelectable: (row) => row.selectable,
-          onDelete: vi.fn(),
-        }}
-      />,
-    );
+  describe('select-all checkbox', () => {
+    test('selects only the selectable rows', async () => {
+      const setSelection = vi.fn();
+      const { user } = renderWithUI(
+        <DataTable
+          {...baseProps}
+          selection={withSelection({ setSelection })}
+        />,
+      );
 
-    await user.click(screen.getByRole('checkbox', { name: 'Select all rows' }));
+      await user.click(
+        screen.getByRole('checkbox', { name: 'Select all rows' }),
+      );
 
-    expect(setSelection).toHaveBeenCalledWith(['a', 'c']);
+      expect(setSelection).toHaveBeenCalledWith(['a', 'c']);
+    });
+
+    test('clears the selection when all selectable rows are already selected', async () => {
+      const setSelection = vi.fn();
+      const { user } = renderWithUI(
+        <DataTable
+          {...baseProps}
+          selection={withSelection({ selection: ['a', 'c'], setSelection })}
+        />,
+      );
+
+      await user.click(
+        screen.getByRole('checkbox', { name: 'Select all rows' }),
+      );
+
+      expect(setSelection).toHaveBeenCalledWith([]);
+    });
+
+    test('is indeterminate when only some selectable rows are selected', () => {
+      const { container } = renderWithUI(
+        <DataTable
+          {...baseProps}
+          selection={withSelection({ selection: ['a'] })}
+        />,
+      );
+
+      expect(
+        container.querySelector('[aria-label="Select all rows"]'),
+      ).toHaveAttribute('data-state', 'indeterminate');
+    });
+
+    test('is disabled when no row is selectable', () => {
+      renderWithUI(
+        <DataTable
+          {...baseProps}
+          selection={withSelection({ isSelectable: () => false })}
+        />,
+      );
+
+      expect(
+        screen.getByRole('checkbox', { name: 'Select all rows' }),
+      ).toBeDisabled();
+    });
+
+    test('is disabled while the selection prop is disabled', () => {
+      renderWithUI(
+        <DataTable
+          {...baseProps}
+          selection={withSelection({ disabled: true })}
+        />,
+      );
+
+      expect(
+        screen.getByRole('checkbox', { name: 'Select all rows' }),
+      ).toBeDisabled();
+    });
   });
 
-  test('marks the non-selectable row checkbox as disabled', () => {
+  describe('row checkbox', () => {
+    test('marks the non-selectable row checkbox as disabled', () => {
+      const { container } = renderWithUI(
+        <DataTable {...baseProps} selection={withSelection()} />,
+      );
+
+      // 3 rows, one of which (Bob) is not selectable. Chakra reflects the
+      // disabled state via `data-disabled` on the checkbox root.
+      expect(container.querySelectorAll('label[data-disabled]')).toHaveLength(
+        1,
+      );
+    });
+
+    test('disables every row checkbox while the selection prop is disabled', () => {
+      const { container } = renderWithUI(
+        <DataTable
+          {...baseProps}
+          selection={withSelection({ disabled: true })}
+        />,
+      );
+
+      // All 3 rows + the select-all checkbox reflect the disabled state.
+      expect(container.querySelectorAll('label[data-disabled]')).toHaveLength(
+        4,
+      );
+    });
+
+    test('reflects the checked state and marks the selected row', () => {
+      const { container } = renderWithUI(
+        <DataTable
+          {...baseProps}
+          selection={withSelection({ selection: ['a'] })}
+        />,
+      );
+
+      expect(
+        screen.getAllByRole('checkbox', { name: 'Select row' })[0],
+      ).toBeChecked();
+      expect(container.querySelectorAll('tr[data-selected]')).toHaveLength(1);
+    });
+
+    test('adds the row id when checking an unselected row', async () => {
+      const setSelection = vi.fn();
+      const { user } = renderWithUI(
+        <DataTable
+          {...baseProps}
+          selection={withSelection({ setSelection })}
+        />,
+      );
+
+      await user.click(
+        screen.getAllByRole('checkbox', { name: 'Select row' })[0],
+      );
+
+      const updater = setSelection.mock.calls[0][0];
+      expect(updater(['x'])).toEqual(['x', 'a']);
+    });
+
+    test('removes the row id when unchecking a selected row', async () => {
+      const setSelection = vi.fn();
+      const { user } = renderWithUI(
+        <DataTable
+          {...baseProps}
+          selection={withSelection({ selection: ['a'], setSelection })}
+        />,
+      );
+
+      await user.click(
+        screen.getAllByRole('checkbox', { name: 'Select row' })[0],
+      );
+
+      const updater = setSelection.mock.calls[0][0];
+      expect(updater(['a', 'z'])).toEqual(['z']);
+    });
+  });
+
+  describe('selection action bar', () => {
+    test('opens with custom actions and a delete button once rows are selected', () => {
+      renderWithUI(
+        <DataTable
+          {...baseProps}
+          selection={withSelection({
+            selection: ['a'],
+            actions: <button>Archive</button>,
+          })}
+        />,
+      );
+
+      expect(screen.getByText('Archive')).toBeInTheDocument();
+      expect(screen.getByText('Delete')).toBeInTheDocument();
+      expect(screen.getByText('1 selected')).toBeInTheDocument();
+    });
+  });
+
+  test('treats a row as selectable by default when isSelectable is omitted', () => {
     const { container } = renderWithUI(
       <DataTable
         {...baseProps}
-        selection={{
-          canSelect: true,
-          items: ROWS,
-          selection: [],
-          setSelection: vi.fn(),
-          isSelectable: (row) => row.selectable,
-          onDelete: vi.fn(),
-        }}
+        selection={withSelection({ isSelectable: undefined })}
       />,
     );
 
-    // 3 rows, one of which (Bob) is not selectable. Chakra reflects the
-    // disabled state via `data-disabled` on the checkbox root.
-    expect(container.querySelectorAll('label[data-disabled]')).toHaveLength(1);
+    // No row is disabled, and select-all pools every row.
+    expect(container.querySelectorAll('label[data-disabled]')).toHaveLength(0);
   });
 });

--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+import {
+  Table,
+  TableCellProps,
+  TableColumnHeaderProps,
+  TableRootProps,
+} from '@chakra-ui/react';
+
+import Pagination from '@/components/Pagination';
+import SelectionActionBar from '@/components/SelectionActionBar';
+import { Checkbox } from '@/components/ui/checkbox';
+import { EmptyState } from '@/components/ui/empty-state';
+
+export type Column<T> = Required<{
+  header: React.ReactNode;
+  cell: (item: T, index: number) => React.ReactNode;
+}> &
+  Partial<{
+    align: 'left' | 'center' | 'right';
+    cellProps: TableCellProps;
+    headerProps: TableColumnHeaderProps;
+  }>;
+
+type Selection<T> = Required<{
+  canSelect: boolean;
+  items: Array<T>;
+  selection: Array<string>;
+  onDelete: () => void;
+  setSelection: React.Dispatch<React.SetStateAction<Array<string>>>;
+}> &
+  Partial<{
+    disabled: boolean;
+    actions: React.ReactNode;
+    isSelectable: (item: T) => boolean;
+  }>;
+
+type DataTableProps<T> = Required<{
+  columns: Array<Column<T>>;
+  currentData: Array<T>;
+  rowId: (item: T) => string;
+  page: number;
+  totalCount: number;
+  empty: { title: string; description?: string; icon?: React.ReactNode };
+  onPageChange: (details: { page: number }) => void;
+}> &
+  Partial<{
+    pageSize: number;
+    selection: Selection<T>;
+    onRowClick: (item: T) => void;
+  }> &
+  TableRootProps;
+
+export default function DataTable<T>({
+  columns,
+  currentData,
+  totalCount,
+  page,
+  pageSize,
+  empty,
+  selection,
+  rowId,
+  onPageChange,
+  onRowClick,
+  ...rootProps
+}: DataTableProps<T>) {
+  const canSelect = selection?.canSelect ?? false;
+  const colSpan = columns.length + (canSelect ? 1 : 0);
+
+  const canSelectRow = (item: T) => selection?.isSelectable?.(item) ?? true;
+  const selectableItems = selection?.items.filter(canSelectRow) ?? [];
+  const selectionCount = selection?.selection.length ?? 0;
+  const hasSelection = selectionCount > 0;
+  const indeterminate = hasSelection && selectionCount < selectableItems.length;
+
+  return (
+    <>
+      <Table.ScrollArea>
+        <Table.Root
+          borderWidth={1}
+          size={{ base: 'sm', md: 'md' }}
+          interactive={totalCount > 0}
+          {...rootProps}
+        >
+          <Table.Header>
+            <Table.Row>
+              {canSelect && selection && (
+                <Table.ColumnHeader width={6}>
+                  <Checkbox
+                    top={0.5}
+                    aria-label="Select all rows"
+                    disabled={
+                      selection.disabled || selectableItems.length === 0
+                    }
+                    checked={
+                      indeterminate ? 'indeterminate' : selectionCount > 0
+                    }
+                    onCheckedChange={(changes) =>
+                      selection.setSelection(
+                        changes.checked ? selectableItems.map(rowId) : [],
+                      )
+                    }
+                  />
+                </Table.ColumnHeader>
+              )}
+              {columns.map((column, index) => (
+                <Table.ColumnHeader
+                  key={index}
+                  textAlign={column.align}
+                  {...column.headerProps}
+                >
+                  {column.header}
+                </Table.ColumnHeader>
+              ))}
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            {currentData.length > 0 ? (
+              currentData.map((item, rowIndex) => {
+                const id = rowId(item);
+                return (
+                  <Table.Row
+                    key={id}
+                    data-selected={
+                      selection?.selection.includes(id) ? '' : undefined
+                    }
+                    _hover={{ cursor: onRowClick ? 'pointer' : 'default' }}
+                    onClick={onRowClick ? () => onRowClick(item) : undefined}
+                  >
+                    {canSelect && selection && (
+                      <Table.Cell onClick={(e) => e.stopPropagation()}>
+                        <Checkbox
+                          top={0.5}
+                          aria-label="Select row"
+                          disabled={selection.disabled || !canSelectRow(item)}
+                          checked={selection.selection.includes(id)}
+                          onCheckedChange={(changes) =>
+                            selection.setSelection((prev) =>
+                              changes.checked
+                                ? [...prev, id]
+                                : prev.filter((x) => x !== id),
+                            )
+                          }
+                        />
+                      </Table.Cell>
+                    )}
+                    {columns.map((column, index) => (
+                      <Table.Cell
+                        key={index}
+                        textAlign={column.align}
+                        {...column.cellProps}
+                      >
+                        {column.cell(item, rowIndex) || '-'}
+                      </Table.Cell>
+                    ))}
+                  </Table.Row>
+                );
+              })
+            ) : (
+              <Table.Row>
+                <Table.Cell colSpan={colSpan}>
+                  <EmptyState
+                    title={empty.title}
+                    description={empty.description}
+                    icon={empty.icon}
+                  />
+                </Table.Cell>
+              </Table.Row>
+            )}
+          </Table.Body>
+        </Table.Root>
+      </Table.ScrollArea>
+
+      <Pagination
+        count={totalCount}
+        page={page}
+        pageSize={pageSize}
+        onPageChange={onPageChange}
+      />
+
+      {canSelect && selection && (
+        <SelectionActionBar
+          open={hasSelection}
+          selectionCount={selectionCount}
+          onDelete={selection.onDelete}
+        >
+          {selection.actions}
+        </SelectionActionBar>
+      )}
+    </>
+  );
+}

--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -150,7 +150,7 @@ export default function DataTable<T>({
                         textAlign={column.align}
                         {...column.cellProps}
                       >
-                        {column.cell(item, rowIndex) || '-'}
+                        {column.cell(item, rowIndex) ?? '-'}
                       </Table.Cell>
                     ))}
                   </Table.Row>

--- a/src/components/filters/Filters.tsx
+++ b/src/components/filters/Filters.tsx
@@ -133,7 +133,7 @@ export default function Filters<T extends Record<string, unknown>>({
               <SlidersHorizontal size={14} />
               Filters
               {activeCount > 0 && (
-                <Badge borderRadius="full" colorPalette="cyan">
+                <Badge variant="surface" borderRadius="full" colorPalette="cyan">
                   {activeCount}
                 </Badge>
               )}

--- a/src/utils/filters.test.ts
+++ b/src/utils/filters.test.ts
@@ -1,6 +1,6 @@
 import { Interval } from './enum';
 
-import { countActiveFilters, paginateData } from './filters';
+import { buildPredicate, countActiveFilters, paginateData } from './filters';
 
 /* ================== Utility Functions ================== */
 
@@ -74,6 +74,78 @@ describe('paginateData', () => {
     const result = paginateData(mockData, 3, 1);
 
     expect(result).toEqual([{ id: 3, name: 'Item 3' }]);
+  });
+});
+
+describe('buildPredicate', () => {
+  type Row = {
+    name: string;
+    email: string;
+    state: string;
+    role: string;
+    nested?: { city: string };
+  };
+
+  const rows: Array<Row> = [
+    { name: 'Alice', email: 'alice@x.io', state: 'active', role: 'admin' },
+    { name: 'Bob', email: 'bob@y.io', state: 'inactive', role: 'guest' },
+    {
+      name: 'Carol',
+      email: 'carol@x.io',
+      state: 'active',
+      role: 'guest',
+      nested: { city: 'Hanoi' },
+    },
+  ];
+
+  test('matches everything when config is empty', () => {
+    expect(rows.filter(buildPredicate<Row>({}))).toEqual(rows);
+  });
+
+  test('searches across fields (case-insensitive, OR)', () => {
+    const result = rows.filter(
+      buildPredicate<Row>({ search: { query: 'ALICE', fields: ['name', 'email'] } }),
+    );
+    expect(result.map((r) => r.name)).toEqual(['Alice']);
+  });
+
+  test('ignores blank/whitespace query', () => {
+    expect(
+      rows.filter(buildPredicate<Row>({ search: { query: '   ', fields: ['name'] } })),
+    ).toEqual(rows);
+  });
+
+  test('supports accessor fields for nested values', () => {
+    const result = rows.filter(
+      buildPredicate<Row>({
+        search: { query: 'hanoi', fields: [(r) => r.nested?.city] },
+      }),
+    );
+    expect(result.map((r) => r.name)).toEqual(['Carol']);
+  });
+
+  test('match keys map to item properties and AND together', () => {
+    const result = rows.filter(
+      buildPredicate<Row>({ match: { state: ['active'], role: ['guest'] } }),
+    );
+    expect(result.map((r) => r.name)).toEqual(['Carol']);
+  });
+
+  test('empty selection is ignored', () => {
+    const result = rows.filter(
+      buildPredicate<Row>({ match: { state: [], role: ['admin'] } }),
+    );
+    expect(result.map((r) => r.name)).toEqual(['Alice']);
+  });
+
+  test('combines search and match', () => {
+    const result = rows.filter(
+      buildPredicate<Row>({
+        search: { query: 'x.io', fields: ['email'] },
+        match: { state: ['active'] },
+      }),
+    );
+    expect(result.map((r) => r.name)).toEqual(['Alice', 'Carol']);
   });
 });
 

--- a/src/utils/filters.ts
+++ b/src/utils/filters.ts
@@ -1,21 +1,3 @@
-export {
-  loadAttendanceFilters,
-  loadDashboardFilters,
-  loadMatchFilters,
-  loadPeriodicTestingFilters,
-  loadTrainingFilters,
-  useAssetFilters,
-  useAttendanceFilters,
-  useCommonParams,
-  useDashboardFilters,
-  useLeagueFilters,
-  useMatchFilters,
-  usePeriodicTestingFilters,
-  useRosterFilters,
-  useTestTypeFilters,
-  useTrainingFilters,
-} from '@/lib/nuqs';
-
 const sameValue = (a: unknown, b: unknown): boolean => {
   if (Array.isArray(a) && Array.isArray(b)) {
     if (a.length !== b.length) return false;
@@ -27,6 +9,7 @@ const sameValue = (a: unknown, b: unknown): boolean => {
 
 /**
  * @description Counts how many filters differ from their defaults, ignoring `page`/`q`.
+ *
  * Array-aware and order-insensitive (URL-decoded arrays may arrive reordered).
  */
 export const countActiveFilters = <T extends Record<string, unknown>>(
@@ -37,6 +20,53 @@ export const countActiveFilters = <T extends Record<string, unknown>>(
     (key) =>
       !['page', 'q'].includes(key) && !sameValue(values[key], defaults[key]),
   ).length;
+
+type FieldAccessor<T> = keyof T | ((item: T) => unknown);
+
+const read = <T>(item: T, field: FieldAccessor<T>): unknown =>
+  typeof field === 'function' ? field(item) : item[field];
+
+interface PredicateConfig<T> {
+  /**
+   * Case-insensitive text search. Passes when ANY field includes the query.
+   * Use a key for direct props or an accessor for nested/derived values
+   * (e.g. `(item) => item.location?.name`).
+   */
+  search?: { query: string; fields: Array<FieldAccessor<T>> };
+  /**
+   * Multi-select filters, AND-ed together. Each key maps a URL query value
+   * (selected options) to the matching item property; an empty selection is
+   * ignored, otherwise `item[key]` must be one of the selected values.
+   */
+  match?: Partial<Record<keyof T, ReadonlyArray<unknown>>>;
+}
+
+/**
+ * @description Replacing the hand-written boolean chains in each table component.
+ *
+ * Behavior is inferred from the config shape: `search` does case-insensitive OR matching, while `match` does AND-ed `includes` checks keyed by item property.
+ */
+export function buildPredicate<T>({ search, match }: PredicateConfig<T>) {
+  const query = search?.query.trim().toLowerCase() ?? '';
+  const matchEntries = Object.entries(match ?? {}) as Array<
+    [keyof T, ReadonlyArray<unknown>]
+  >;
+
+  return (item: T): boolean => {
+    if (query) {
+      const matched = search!.fields.some((field) => {
+        const value = read(item, field);
+        return typeof value === 'string' && value.toLowerCase().includes(query);
+      });
+      if (!matched) return false;
+    }
+
+    return matchEntries.every(
+      ([key, selected]) =>
+        selected.length === 0 || selected.includes(item[key]),
+    );
+  };
+}
 
 export function paginateData<T>(
   data: Array<T>,

--- a/src/utils/helper.test.ts
+++ b/src/utils/helper.test.ts
@@ -1,12 +1,10 @@
 import { ALL } from './constant';
 import {
-  AssetCategory,
   AssetCondition,
   AttendanceStatus,
   LeagueStatus,
   MatchStatus,
   SessionStatus,
-  UserRole,
   UserState,
 } from './enum';
 
@@ -18,10 +16,6 @@ describe('getColor', () => {
     { value: null, expected: 'gray' },
     { value: undefined, expected: 'gray' },
     { value: 'unknown', expected: 'black' },
-    // UserRole
-    { value: UserRole.SUPER_ADMIN, expected: 'orange' },
-    { value: UserRole.COACH, expected: 'purple' },
-    { value: UserRole.PLAYER, expected: 'blue' },
     // UserState
     { value: UserState.ACTIVE, expected: 'green' },
     { value: UserState.TEMPORARILY_ABSENT, expected: 'orange' },
@@ -32,10 +26,6 @@ describe('getColor', () => {
     { value: AssetCondition.FAIR, expected: 'orange' },
     { value: AssetCondition.POOR, expected: 'red' },
     { value: AssetCondition.OBSOLETE, expected: 'gray' },
-    // AssetCategory
-    { value: AssetCategory.EQUIPMENT, expected: 'green' },
-    { value: AssetCategory.TRAINING, expected: 'orange' },
-    { value: AssetCategory.OTHERS, expected: 'gray' },
     // LeagueStatus
     { value: LeagueStatus.UPCOMING, expected: 'orange' },
     { value: LeagueStatus.ONGOING, expected: 'green' },

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -2,21 +2,18 @@ import { ColorPalette } from '@chakra-ui/react';
 
 import { ALL } from './constant';
 import {
-  AssetCategory,
   AssetCondition,
   AttendanceStatus,
   EmailStatus,
   LeagueStatus,
   MatchStatus,
   SessionStatus,
-  UserRole,
   UserState,
 } from './enum';
 
 const COLOR_MAP: Partial<Record<ColorPalette, Array<string>>> = {
-  blue: [UserRole.PLAYER, EmailStatus.SENT],
+  blue: [EmailStatus.SENT],
   gray: [
-    AssetCategory.OTHERS,
     AssetCondition.OBSOLETE,
     EmailStatus.CANCELED,
     EmailStatus.QUEUED,
@@ -26,7 +23,6 @@ const COLOR_MAP: Partial<Record<ColorPalette, Array<string>>> = {
     UserState.UNKNOWN,
   ],
   green: [
-    AssetCategory.EQUIPMENT,
     AssetCondition.GOOD,
     AttendanceStatus.ON_TIME,
     EmailStatus.CLICKED,
@@ -38,17 +34,14 @@ const COLOR_MAP: Partial<Record<ColorPalette, Array<string>>> = {
     UserState.ACTIVE,
   ],
   orange: [
-    AssetCategory.TRAINING,
     AssetCondition.FAIR,
     AttendanceStatus.LATE,
     EmailStatus.DELIVERY_DELAYED,
     EmailStatus.SCHEDULED,
     LeagueStatus.UPCOMING,
-    UserRole.SUPER_ADMIN,
     UserState.TEMPORARILY_ABSENT,
     SessionStatus.SCHEDULED,
   ],
-  purple: [UserRole.COACH],
   red: [
     AssetCondition.POOR,
     AttendanceStatus.ABSENT,


### PR DESCRIPTION
#### New ✨

- Add `buildPredicate<T>` in `src/utils/filters.ts` with accompanying unit tests to support declarative search + multi-select matching.
- Introduce a reusable `DataTable<T>` component (and tests), and migrate multiple existing tables to use it.

#### Improvements 🙌

- Update several UI details (notably `Badge` variants) and fix imports to use `@/lib/nuqs` instead of re-exporting from `@/utils/filters`.

_Resolve #210_
