### PR TITLE
Fix serve public static assets without auth redirect

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -72,7 +72,10 @@ export default function LoginPage() {
           invalid={!!errors.password}
           errorText={errors.password?.message}
         >
-          <PasswordInput {...register('password')} />
+          <PasswordInput
+            autoComplete="current-password"
+            {...register('password')}
+          />
         </Field>
 
         <ChakraLink

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -83,8 +83,8 @@ export const config = {
      * - api (API routes)
      * - _next/static (static files)
      * - _next/image (image optimization files)
-     * - Metadata files
+     * - static asset requests with common image extensions (png, svg, ico, etc.)
      */
-    '/((?!api|_next/static|_next/image|icon.svg).*)',
+    '/((?!api|_next/static|_next/image|.*\\.(?:png|svg|jpg|jpeg|gif|ico|webp)$).*)',
   ],
 };

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -16,13 +16,8 @@ export const AUTH_ROUTES = new Set([
 /**
  * An array of routes that are accessible to the public.
  * These routes do not require authentication
- * @type {Array<string>}
  */
-export const PUBLIC_ROUTES = new Set([
-  ...AUTH_ROUTES,
-  '/logo.svg',
-  '/squiggle.svg',
-]);
+export const PUBLIC_ROUTES = new Set([...AUTH_ROUTES]);
 
 /**
  * The default redirect path after logging in.


### PR DESCRIPTION
#### Improvements 🙌

- Simplified `PUBLIC_ROUTES` to only include auth-related routes (static assets no longer need explicit whitelisting).
- Improved the login form by adding `autoComplete="current-password"` to the password field.

#### Bug Fixes 🐛

- Update the middleware matcher to bypass auth for common image extensions (png/svg/jpg/jpeg/gif/ico/webp) instead of a single hardcoded asset.

_Resolve #235_
